### PR TITLE
Gestion de la réouverture de PR déjà mergée + amélioration ergonomique du rebase

### DIFF
--- a/feature.sh
+++ b/feature.sh
@@ -71,7 +71,6 @@ feature_start() {
 feature_restart() {
     local feature_type=$1
     local feature_name=$2
-    local BASED_ON=$3
     local branch=$1/$feature_name
     local branch_PR=$prefix_PR$branch
 

--- a/feature.sh
+++ b/feature.sh
@@ -64,7 +64,7 @@ feature_start() {
         echo "On est dans la Matrix"
     fi
 
-    exit_safe 1
+    exit_safe 0
 }
 
 feature_restart() {
@@ -91,7 +91,7 @@ feature_restart() {
         echo "🚨 ATTENTION : Le code de '$branch' et '$branch_PR' est différent !"
         printf "\033[1;31mLe restart ne peut se faire que sur deux branches identiques d'un point de vue code\033[0m\n"
 
-        exit_safe 0
+        exit_safe 1
     else
         echo "✅ Les deux branches contiennent exactement le même code."
     fi

--- a/feature.sh
+++ b/feature.sh
@@ -51,10 +51,11 @@ feature_start() {
         git checkout $reference_branch --quiet
         echo "Create pull request branch $branch_PR branch"
         git checkout -b $branch_PR --quiet
+        git commit --allow-empty -m "$prefix_init_commit $branch $suffix_init_commit" --quiet
         git push $j2s_remote $branch_PR --quiet
         echo "Create working branch $branch branch"
         git checkout -b $branch --quiet
-        git commit --allow-empty -m "$prefix_init_commit $branch $suffix_init_commit" --quiet
+        git commit --allow-empty -m "$prefix_commit commit for automatic PR creation - this commit will be deleted by squash and merge - START $branch $suffix_init_commit" --quiet
         git push --set-upstream $j2s_remote $branch --quiet
         git branch -D $branch_PR --quiet
         echo "Create pull request"
@@ -109,10 +110,9 @@ feature_restart() {
 
     echo "Create working branch $branch"
     git checkout -b $branch --quiet
-    git commit --allow-empty -m "$prefix_init_commit $branch Restart $suffix_init_commit" --quiet
+    git commit --allow-empty -m "$prefix_commit commit for automatic PR creation - this commit will be deleted by squash and merge - RESTART $branch $suffix_init_commit" --quiet
     git push --set-upstream $j2s_remote $branch --quiet
     git branch -D $branch_PR --quiet
     echo "Create pull request"
     gh pr create --title "$feature_name - RESTART" --body "https://justsimplesolutions.atlassian.net/browse/"$feature_name --base=$branch_PR --head=$branch --label "NFR"
-
 }

--- a/feature.sh
+++ b/feature.sh
@@ -57,6 +57,7 @@ feature_start() {
         git checkout -b $branch --quiet
         git commit --allow-empty -m "$prefix_commit commit for automatic PR creation - this commit will be deleted by squash and merge - START $branch $suffix_init_commit" --quiet
         git push --set-upstream $j2s_remote $branch --quiet
+        current_branch="$branch"
         git branch -D $branch_PR --quiet
         echo "Create pull request"
         gh pr create --title $feature_name --body "https://justsimplesolutions.atlassian.net/browse/"$feature_name --base=$branch_PR --head=$branch --label "NFR"
@@ -112,6 +113,7 @@ feature_restart() {
     git checkout -b $branch --quiet
     git commit --allow-empty -m "$prefix_commit commit for automatic PR creation - this commit will be deleted by squash and merge - RESTART $branch $suffix_init_commit" --quiet
     git push --set-upstream $j2s_remote $branch --quiet
+    current_branch="$branch"
     git branch -D $branch_PR --quiet
     echo "Create pull request"
     gh pr create --title "$feature_name - RESTART" --body "https://justsimplesolutions.atlassian.net/browse/"$feature_name --base=$branch_PR --head=$branch --label "NFR"

--- a/feature.sh
+++ b/feature.sh
@@ -66,7 +66,6 @@ feature_start() {
     exit_safe 1
 }
 
-
 feature_restart() {
     local feature_type=$1
     local feature_name=$2
@@ -81,8 +80,8 @@ feature_restart() {
     fi
 
     # On remet les branches à jour en local.
-    update_or_checkout_branch $branch_PR
-    update_or_checkout_branch $branch
+    checkout_or_create_branch $branch_PR
+    checkout_or_create_branch $branch
 
     branches_have_same_code "$branch" "$branch_PR"
 
@@ -102,10 +101,10 @@ feature_restart() {
     #####################################################
     git checkout $branch_PR --quiet
     
-    # Suppression locale de la branche, avec un arrêt en cas d'échec
-    git branch -d "$branch"
+    # Suppression locale de la branche - on ignore l'erreur si elle n'existe déjà pas
+    git branch -d "$branch" 2>/dev/null
   
-    # Suppression de la branche sur le remote
+    # Suppression de la branche sur le remote - on ignore l'erreur si elle n'existe déjà pas
     git push origin --delete "$branch" 2>/dev/null
 
     echo "Create working branch $branch"

--- a/feature.sh
+++ b/feature.sh
@@ -40,7 +40,6 @@ feature_start() {
 
         printf "%sJGit va créer la branche %s%s%s%s et sa PR associée qui se basera sur la branche %s%s%s\n" \
         "$(tput setaf 2)" "$(tput setaf 1)" "$branch" "$(tput sgr0)"  "$(tput setaf 2)" "$(tput setaf 1)" "$reference_branch" "$(tput sgr0)"
-        
         # Demander confirmation à l'utilisateur
         read -p "Souhaitez-vous continuer ? (y/n) " user_input
         if [[ "$user_input" != "y" ]]; then
@@ -65,4 +64,64 @@ feature_start() {
     fi
 
     exit_safe 1
+}
+
+
+feature_restart() {
+    local feature_type=$1
+    local feature_name=$2
+    local BASED_ON=$3
+    local branch=$1/$feature_name
+    local branch_PR=$prefix_PR$branch
+
+    # Vérifier si la branche référence existe
+    if ! git rev-parse --verify "$branch_PR" >/dev/null 2>&1 && ! git ls-remote --heads origin "$branch_PR" >/dev/null 2>&1; then
+        echo "Erreur : La branche de PR '$branch_PR' n'existe pas."
+        exit_safe 1
+    fi
+
+    # On remet les branches à jour en local.
+    update_or_checkout_branch $branch_PR
+    update_or_checkout_branch $branch
+
+    branches_have_same_code "$branch" "$branch_PR"
+
+    # Vérifier le résultat et afficher un message personnalisé
+    if [[ $? -ne 0 ]]; then
+        echo "🚨 ATTENTION : Le code de '$branch' et '$branch_PR' est différent !"
+        printf "\033[1;31mLe restart ne peut se faire que sur deux branches identiques d'un point de vue code\033[0m\n"
+
+        exit_safe 0
+    else
+        echo "✅ Les deux branches contiennent exactement le même code."
+    fi
+
+
+    #####################################################
+    # On supprime la branche de travail pour la recréer
+    #####################################################
+    git checkout $branch_PR --quiet
+    
+    # Suppression locale de la branche, avec un arrêt en cas d'échec
+    git branch -d "$branch"
+    if [ $? -ne 0 ]; then
+        echo "Erreur : La branche '$branch' n'a pas pu être supprimée en local. Elle n'est peut-être pas fusionnée."
+        exit 1
+    fi
+  
+    # Suppression de la branche sur le remote
+    git push origin --delete "$branch"
+    if [ $? -ne 0 ]; then
+        echo "Erreur : La branche '$branch' n'a pas pu être supprimée sur le remote."
+        exit 1
+    fi
+
+    echo "Create working branch $branch"
+    git checkout -b $branch --quiet
+    git commit --allow-empty -m "$prefix_init_commit $branch $suffix_init_commit" --quiet
+    git push --set-upstream $j2s_remote $branch --quiet
+    git branch -D $branch_PR --quiet
+    echo "Create pull request"
+    gh pr create --title $feature_name --body "https://justsimplesolutions.atlassian.net/browse/"$feature_name --base=$branch_PR --head=$branch --label "NFR"
+
 }

--- a/feature.sh
+++ b/feature.sh
@@ -104,24 +104,16 @@ feature_restart() {
     
     # Suppression locale de la branche, avec un arrêt en cas d'échec
     git branch -d "$branch"
-    if [ $? -ne 0 ]; then
-        echo "Erreur : La branche '$branch' n'a pas pu être supprimée en local. Elle n'est peut-être pas fusionnée."
-        exit 1
-    fi
   
     # Suppression de la branche sur le remote
-    git push origin --delete "$branch"
-    if [ $? -ne 0 ]; then
-        echo "Erreur : La branche '$branch' n'a pas pu être supprimée sur le remote."
-        exit 1
-    fi
+    git push origin --delete "$branch" 2>/dev/null
 
     echo "Create working branch $branch"
     git checkout -b $branch --quiet
-    git commit --allow-empty -m "$prefix_init_commit $branch $suffix_init_commit" --quiet
+    git commit --allow-empty -m "$prefix_init_commit $branch Restart $suffix_init_commit" --quiet
     git push --set-upstream $j2s_remote $branch --quiet
     git branch -D $branch_PR --quiet
     echo "Create pull request"
-    gh pr create --title $feature_name --body "https://justsimplesolutions.atlassian.net/browse/"$feature_name --base=$branch_PR --head=$branch --label "NFR"
+    gh pr create --title "$feature_name - RESTART" --body "https://justsimplesolutions.atlassian.net/browse/"$feature_name --base=$branch_PR --head=$branch --label "NFR"
 
 }

--- a/functions.sh
+++ b/functions.sh
@@ -8,6 +8,7 @@
 
 # fonction à appeler systématiquement permet de remettre les données stashée au départ en cas d'arrêt du script.
 exit_safe() {
+    echo "checkout on $current_branch"
     checkout_if_exists $current_branch
 
     if $stash; then

--- a/functions.sh
+++ b/functions.sh
@@ -12,12 +12,11 @@ exit_safe() {
         git stash pop
     fi
 
-    if [[ $1 == 0 ]]; then
+    if [[ $1 != 0 ]]; then
         echo "/!\ Script finished in error! Be careful about your branch management on local."
-
-        exit $1
     fi
 
+    checkout_if_exists $current_branch
     exit $1
 }
 
@@ -34,7 +33,7 @@ verify_stash() {
         read -p "Do you want to stash and unstash changes at the end of process ? [y/n] " yn
         echo
         if [[ ! $yn =~ ^[Yy]$ ]]; then
-            exit_safe 0
+            exit_safe 1
         fi
         git stash save "[jGIT]"
         stash=true;
@@ -53,7 +52,7 @@ get_reference_branch() {
 
     if [ -z "$feature_type" ]; then
         echo "Erreur: Aucun feature_type fourni."
-        exit_safe 0
+        exit_safe 1
     fi
 
     # Vérifier la branche en fonction du type de feature
@@ -131,7 +130,7 @@ cherry_pick() {
         if [[ "$user_input" != "y" ]]; then
             echo "Opération annulée."
             git cherry-pick --abort
-            exit_safe 0
+            exit_safe 1
         fi
     fi
 }

--- a/functions.sh
+++ b/functions.sh
@@ -117,14 +117,27 @@ cherry_pick() {
     fi
 }
 
-# Permet d'afficher le git log bien présenté avec les couleurs et l'arbres des commits
 git_history_with_merges() {
-  local branch="${1:-HEAD}"  # Si aucun argument n'est fourni, utilise HEAD (branche actuelle)
+  local feature_branch="${1:-HEAD}"     # Branche à afficher (par défaut HEAD)
+  local reference_branch="${2}"         # Branche de référence (optionnelle)
 
-  echo "Historique de la branche '$branch' avec les merges :"
-  git log --oneline --graph --decorate --all --abbrev-commit --pretty=format:'%C(yellow)%h%C(reset) - %C(cyan)%d%C(reset) %s %C(blue)(%cr) %C(reset)%C(green)<%an>%C(reset)' "$branch"
+  printf "\033[1;31mHistorique A VERIFIER de la branche '%s'%s :\033[0m\n" "$feature_branch" "$( [[ -n "$reference_branch" ]] && printf " depuis '%s' (A lire de bas en haut)" "$reference_branch" )"
+
+  if [[ -n "$reference_branch" ]]; then
+    git log --oneline --graph --decorate --abbrev-commit --boundary \
+      --pretty=format:'%C(yellow)%h%C(reset) - %C(cyan)%d%C(reset) %s %C(blue)(%cr) %C(reset)%C(green)<%an>%C(reset)' \
+      "$feature_branch" "^$reference_branch"
+  else
+    git log --oneline --graph --decorate --abbrev-commit \
+      --pretty=format:'%C(yellow)%h%C(reset) - %C(cyan)%d%C(reset) %s %C(blue)(%cr) %C(reset)%C(green)<%an>%C(reset)' \
+      "$feature_branch"
+  fi
+
+  printf "\nVous pouvez afficher un arbre plus détaillé, si besoin, en copiant collant la commande ci-dessous dans un autre terminal\n"
+  printf "git log --oneline --graph --decorate --all --abbrev-commit --pretty=format:'%%C(yellow)%%h%%C(reset) - %%C(cyan)%%d%%C(reset) %%s %%C(blue)(%%cr) %%C(reset)%%C(green)<%%an>%%C(reset)' %s\n\n\n" "$feature_branch"
 }
 
+  #
 # Permt d'afficher un commit sur une ligne avec son hash et son nom
 get_commit_info() {
   local commit_hash=$1

--- a/functions.sh
+++ b/functions.sh
@@ -153,6 +153,7 @@ cherry_pick() {
     fi
 }
 
+# Permet d'afficher le git log bien présenté depuis le dernier noeud en commun avec la $reference_branch et avec les couleurs et l'arbres des commits
 git_history_with_merges() {
   local feature_branch="${1:-HEAD}"     # Branche à afficher (par défaut HEAD)
   local reference_branch="${2}"         # Branche de référence (optionnelle)
@@ -267,34 +268,6 @@ checkout_if_exists() {
     exit_safe 1
   fi
 }
-
-# Si la branche existe en local on la met à jour
-# Si elle existe sur le remote on le récupère
-# Sinon on la crée en local
-update_or_checkout_branch() {
-    local branch="$1"
-
-    if [[ -z "$branch" ]]; then
-      echo -e "\033[1;31mErreur : Aucun nom de branche fourni.\033[0m" >&2
-      return 1
-    fi
-
-    if git show-ref --verify --quiet "refs/heads/$branch"; then
-        # La branche existe en local
-        git checkout "$branch" --quiet || return 1
-        git pull --ff-only origin "$branch" --quiet || return 1
-
-    elif git ls-remote --exit-code --heads origin "$branch" > /dev/null; then
-        # La branche existe sur origin mais pas en local
-        git fetch origin --quiet || return 1
-        git checkout -b "$branch" "origin/$branch" --quiet || return 1
-
-    else
-        # La branche n'existe ni en local ni sur origin → Création locale
-        git checkout -b "$branch" --quiet|| return 1
-    fi
-}
-
 
 # Script de nettoyage qui va nettoyer toutes les branches utiles à jgit mais pas au développeur.
 clean_branches() {

--- a/functions.sh
+++ b/functions.sh
@@ -137,7 +137,6 @@ git_history_with_merges() {
   printf "git log --oneline --graph --decorate --all --abbrev-commit --pretty=format:'%%C(yellow)%%h%%C(reset) - %%C(cyan)%%d%%C(reset) %%s %%C(blue)(%%cr) %%C(reset)%%C(green)<%%an>%%C(reset)' %s\n\n\n" "$feature_branch"
 }
 
-  #
 # Permt d'afficher un commit sur une ligne avec son hash et son nom
 get_commit_info() {
   local commit_hash=$1

--- a/functions.sh
+++ b/functions.sh
@@ -45,7 +45,7 @@ verify_stash() {
 # Les paramètre du fichier .jgit/conf_local.sh seront pris en 2nd
 # Sinon le script prendra la première branche qui existe parmis les fallback_branches
 #
-#Si la branche de référence n'existe pas une erreur est lancée.
+# Si la branche de référence n'existe pas une erreur est lancée.
 get_reference_branch() {
     local feature_type=$1
     local fallback_branches=("develop2" "master2" "develop" "master" "main")

--- a/functions.sh
+++ b/functions.sh
@@ -8,6 +8,8 @@
 
 # fonction à appeler systématiquement permet de remettre les données stashée au départ en cas d'arrêt du script.
 exit_safe() {
+    checkout_if_exists $current_branch
+
     if $stash; then
         git stash pop
     fi
@@ -16,7 +18,6 @@ exit_safe() {
         echo "/!\ Script finished in error! Be careful about your branch management on local."
     fi
 
-    checkout_if_exists $current_branch
     exit $1
 }
 

--- a/jgit.sh
+++ b/jgit.sh
@@ -118,6 +118,9 @@ if [[ $JGIT_TYPE == "feature" ]] || [[ $JGIT_TYPE == "hotfix" ]]; then
     if [[ $JGIT_ACTION == "start" ]]; then
         verify_stash
         feature_start $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON;
+    elif [[ $JGIT_ACTION == "restart" ]]; then
+        verify_stash
+        feature_restart $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON
     elif [[ $JGIT_ACTION == "rebase" ]]; then
         verify_stash
         feature_rebase $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON

--- a/jgit.sh
+++ b/jgit.sh
@@ -29,8 +29,8 @@ prefix_PR="__PR__"
 prefix_commit="[jgit]"
 prefix_init_commit="$prefix_commit INIT"
 suffix_init_commit="[empty_commit]"
-stash=false;
 
+stash=false;
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 ################################################################################

--- a/jgit.sh
+++ b/jgit.sh
@@ -122,7 +122,7 @@ if [[ $JGIT_TYPE == "feature" ]] || [[ $JGIT_TYPE == "hotfix" ]]; then
         feature_start $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON;
     elif [[ $JGIT_ACTION == "restart" ]]; then
         verify_stash
-        feature_restart $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON
+        feature_restart $JGIT_TYPE $JGIT_NAME
     elif [[ $JGIT_ACTION == "rebase" ]]; then
         verify_stash
         feature_rebase $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON

--- a/jgit.sh
+++ b/jgit.sh
@@ -31,6 +31,8 @@ prefix_init_commit="$prefix_commit INIT"
 suffix_init_commit="[empty_commit]"
 stash=false;
 
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
 ################################################################################
 # Help                                                                         #
 ################################################################################
@@ -82,7 +84,7 @@ while [[ $# -gt 0 ]]; do
         shift 2         # Passer à l'argument suivant
       else
         echo "Erreur : L'option --based-on nécessite un argument." >&2
-        exit 1
+        exit_safe 1
       fi
       ;;
     *)
@@ -102,14 +104,14 @@ remotes=$( git remote -v )
 
 if [[ $remotes != *$j2s_remote* ]]; then
   echo "Please configure J2S remote as "$j2s_remote
-  exit_safe 0
+  exit_safe 1
 fi
 
 # Manage syntax
 if [[ $JGIT_TYPE == "feature" ]] || [[ $JGIT_TYPE == "hotfix" ]]; then
     if [[ -z $JGIT_NAME ]]; then
         echo "Please set a $JGIT_TYPE name as third argument"
-        exit_safe 0;
+        exit_safe 1;
     fi
     
     if [[ -z $JGIT_ACTION ]]; then
@@ -126,7 +128,7 @@ if [[ $JGIT_TYPE == "feature" ]] || [[ $JGIT_TYPE == "hotfix" ]]; then
         feature_rebase $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON
     else
         echo "argument $JGIT_ACTION note supported"
-        exit_safe 0
+        exit_safe 1
     fi
 elif [[ $JGIT_TYPE == "release" ]]; then
     if [[ -z $JGIT_ACTION ]]; then
@@ -140,21 +142,21 @@ elif [[ $JGIT_TYPE == "release" ]]; then
     elif [[ $JGIT_ACTION == "merge" ]]; then 
         if [[ -z $JGIT_NAME ]]; then
             echo "Please set a branch name as third argument"
-            exit_safe 0;
+            exit_safe 1;
         fi
         branch_PR=$prefix_PR$JGIT_NAME
         release_merge;
     else
         echo "argument $JGIT_ACTION not supported"
-        exit_safe 0
+        exit_safe 1
     fi
 elif [[ $JGIT_TYPE == "help" ]] || [[ $JGIT_TYPE == "-h" ]]; then
     help
-    exit_safe 1;
+    exit_safe 0;
 elif [[ $JGIT_TYPE == "clean" ]]; then
     clean_branches
 else
     echo "argument $JGIT_TYPE not supported"
-    exit_safe 0
+    exit_safe 1
 fi
-exit_safe 1
+exit_safe 0

--- a/rebase.sh
+++ b/rebase.sh
@@ -84,7 +84,7 @@ feature_rebase() {
     fi
 
     # On est dans le cas d'une PR qui déjà été mergée puis réouverte, on affiche la liste complète pour bien la valider visuellement.
-    if [[ $commits_in_advance_on_PR -gt 2 ]]; then
+    if [[ ${#commits_in_advance_on_PR[@]} -gt 2 ]]; then
         printf "%sLes commits suivants sont présents sur la branche %s%s%s actuelle mais pas sur la branche %s%s%s. Il seront repris sur la future branche %s%s%s%s\n" \
         "$(tput setaf 2)"  \
         "$(tput setaf 1)" "$branch_PR" "$(tput setaf 2)" \

--- a/rebase.sh
+++ b/rebase.sh
@@ -51,8 +51,8 @@ feature_rebase() {
 
     git checkout $branch --quiet
 
-    # Récupérer le dernier commit avec le pattern jgit
-    last_init_commit=$(get_last_commit_with_pattern)
+    # Récupérer le dernier commit avec le pattern jgit de démarrage de feature
+    last_init_commit=$(get_last_commit_with_pattern "$prefix_init_commit $feature_type")
     if [ -z "$last_init_commit" ]; then
         echo "Aucun commit trouvé avec le pattern jgit"
         exit_safe 1
@@ -78,11 +78,11 @@ feature_rebase() {
         "$(tput setaf 1)" "${last_init_commit[0]}" "$(tput setaf 2)" \
         "$(tput sgr0)"
 
-        exit_safe 0
+        #exit_safe 0
     fi
 
     # On est dans le cas d'une PR qui déjà été mergée puis réouverte, on affiche la liste complète pour bien la valider visuellement.
-    if [[ ${#commits_in_advance_on_PR[@]} -gt 2 ]]; then
+    if [[ ${#commits_in_advance_on_PR[@]} -gt 1 ]]; then
         printf "%sLes commits suivants sont présents sur la branche %s%s%s actuelle mais pas sur la branche %s%s%s. Il seront repris sur la future branche %s%s%s%s\n" \
         "$(tput setaf 2)"  \
         "$(tput setaf 1)" "$branch_PR" "$(tput setaf 2)" \

--- a/rebase.sh
+++ b/rebase.sh
@@ -55,8 +55,6 @@ feature_rebase() {
     fi
 
     git checkout $branch --quiet
-
-    git checkout $branch --quiet
     # Lister les commits sur la branche feature en avance de la branche PR (dans l'ordre du plus ancien au plus récent)
     local commits=($(git rev-list "$branch_PR..$branch" | tail -r))
 
@@ -144,7 +142,7 @@ feature_rebase() {
     fi
 
     # On met à jour la branche de référence par rapport au remote pour être bien à jour
-    echo "Checkout and reset $reference_branch branch"
+    echo "Checkout and pull $reference_branch branch"
     git checkout $reference_branch --quiet
     git pull $j2s_remote $reference_branch --quiet
 
@@ -180,10 +178,10 @@ feature_rebase() {
 
     # on push force les nouvelles branches fraichement rebasée.
     git checkout $branch_PR
-    git push --force --set-upstream origin "$branch_PR"
+    git push --force --set-upstream $j2s_remote "$branch_PR"
 
     git checkout $branch
-    git push --force --set-upstream origin "$branch"
+    git push --force --set-upstream $j2s_remote "$branch"
 
     git checkout $branch
     clean_branches

--- a/rebase.sh
+++ b/rebase.sh
@@ -173,8 +173,9 @@ feature_rebase() {
         git checkout $reference_branch --quiet
         git branch -D $branch
         git branch -D $branch_PR
+        checkout_if_exists  $branch
         echo "Pensez à re-pull vos branches depuis Github."
-        exit_safe 0
+        exit_safe 1
     fi
 
     # on push force les nouvelles branches fraichement rebasée.

--- a/rebase.sh
+++ b/rebase.sh
@@ -143,8 +143,8 @@ feature_rebase() {
         # exit_safe 1
 
         # DEBUT DE Partie à supprimer une fois qu'il n'y aura plus de vieille feature.
-        printf "\nCe cas peut se poser pour les features créées avant la v1.15 de jgit.\n"
-        printf "\nDans ce cas : vous devez voir uniquement le commit d'init dans la \"Liste des commits communs\" et dans la \"Liste des commits repris\".\n"
+        printf "\nCe cas peut se poser pour les features créées avant la v1.15 de jgit et donc être un faux positif.\n"
+        printf "\nDans ce cas : vous devez voir uniquement le commit d'init dans la \"Liste des commits repris\".\n"
         printf "Attention en continuant ce process tous les commits existants dans la \"Liste des commits repris\"  seront perdus !!!!!!\n"
 
         # Demander confirmation à l'utilisateur

--- a/rebase.sh
+++ b/rebase.sh
@@ -137,7 +137,7 @@ feature_rebase() {
     
     # On propose à l'utlisateur de vérifier son arbre GIT avant de pusher en force sur le remote.
     git checkout $branch
-    git_history_with_merges
+    git_history_with_merges "$branch" "$reference_branch"
 
     read -p "Confirmez-vous que le rebase s'est bien passé, les branches vont être push --force ? (y/n) " user_input
     if [[ "$user_input" != "y" ]]; then

--- a/rebase.sh
+++ b/rebase.sh
@@ -91,7 +91,7 @@ feature_rebase() {
     for commit in "${commits_on_PR[@]}"; do
         if is_merge_commit "$commit"; then
             printf "\033[1;31mLe commit \033[1;32m%s\033[1;31m est un commit de fusion. On ne peut pas rebase automatiquement un commit de fusion.\033[0m\n" "$commit"  
-            printf "Il ne faut pas mélanger rebase et merge, la prochaine fois merci de ne faire que des rebases ;). Pensez à toujours squash and merge vos PRs"
+            printf "Il ne faut pas mélanger rebase et merge, la prochaine fois merci de ne faire que des rebases ;).\nPensez à toujours squash and merge vos PRs\n"
 
             exit_safe 1
         fi
@@ -100,7 +100,7 @@ feature_rebase() {
     for commit in "${commits[@]}"; do
         if is_merge_commit "$commit"; then
             printf "\033[1;31mLe commit \033[1;32m%s\033[1;31m est un commit de fusion. On ne peut pas rebase automatiquement un commit de fusion.\033[0m\n" "$commit"  
-            printf "Il ne faut pas mélanger rebase et merge, la prochaine fois merci de ne faire que des rebases ;). Pensez à toujours squash and merge vos PRs"
+            printf "Il ne faut pas mélanger rebase et merge, la prochaine fois merci de ne faire que des rebases ;).\nPensez à toujours squash and merge vos PRs\n"
 
             exit_safe 1
         fi
@@ -183,8 +183,7 @@ feature_rebase() {
     git checkout $branch
     git push --force --set-upstream $j2s_remote "$branch"
 
-    git checkout $branch
+    current_branch="$branch"
     clean_branches
-
     printf "%sRebase terminé avec succès%s\n" "$(tput setaf 2)" "$(tput sgr0)"
 }

--- a/rebase.sh
+++ b/rebase.sh
@@ -61,11 +61,10 @@ feature_rebase() {
     fi
 
     #############################################################################
-    # Cette partie permet de gérer le cas où la PR avait déjà été validé et mergée
+    # Cette partie permet de gérer le cas où la PR avait déjà été validée et mergée
     # puis réouverte par la suite, en effet dans ce cas là il y a déjà des commits 
     # présents sur la branche PR qui ne doivent pas être oubliés
     ##############################################################################
-    
     
     # Récupérer la liste des commits en avance sur branch_PR
     local commits_in_advance_on_PR=($(git rev-list "$reference_branch..$branch_PR"))
@@ -125,7 +124,7 @@ feature_rebase() {
     git checkout $reference_branch --quiet
     git pull $j2s_remote $reference_branch --quiet
 
-    # rebase de la branche PR par application des commit déjà présent sur l'ancienne branche PR en cherry pick
+    # rebase de la branche PR par application des commits déjà présents sur l'ancienne branche PR en cherry pick
     checkout_or_create_branch $branch_PR_rebase
     cherry_pick_commits "${commits_in_advance_on_PR[@]}"
 

--- a/rebase.sh
+++ b/rebase.sh
@@ -51,7 +51,7 @@ feature_rebase() {
         git checkout -b $branch_PR $j2s_remote/$branch_PR
     fi
 
-    git checkout $branch
+    git checkout $branch --quiet
 
     # Récupérer le dernier commit avec le pattern jgit
     last_init_commit=$(get_last_commit_with_pattern)
@@ -59,6 +59,47 @@ feature_rebase() {
         echo "Aucun commit trouvé avec le pattern jgit"
         exit_safe 1
     fi
+
+    #############################################################################
+    # Cette partie permet de gérer le cas où la PR avait déjà été validé et mergée
+    # puis réouverte par la suite, en effet dans ce cas là il y a déjà des commits 
+    # présents sur la branche PR qui ne doivent pas être oubliés
+    ##############################################################################
+    
+    
+    # Récupérer la liste des commits en avance sur branch_PR
+    local commits_in_advance_on_PR=($(git rev-list "$reference_branch..$branch_PR"))
+
+    # normalement le premier commit de la branche de travail et de la branche de PR doivent être les mêmes
+    # Si ce n'est pas les mêmes c'est pas normal on coupe le script.
+    if [[ "${commits_in_advance_on_PR[0]}" != $last_init_commit ]]; then
+        printf "%sLe premier commit de la branche %s%s%s est %s%s%s. Sur la branche %s%s%s il vaut %s%s%s, ce n'est pas normal%s\n" \
+        "$(tput setaf 2)"  \
+        "$(tput setaf 1)" "$branch_PR" "$(tput setaf 2)" \
+        "$(tput setaf 1)" "${commits_in_advance_on_PR[0]}" "$(tput setaf 2)" \
+        "$(tput setaf 1)" "$branch" "$(tput setaf 2)" \
+        "$(tput setaf 1)" "${last_init_commit[0]}" "$(tput setaf 2)" \
+        "$(tput sgr0)"
+
+        exit_safe 0
+    fi
+
+    # On est dans le cas d'une PR qui déjà été mergée puis réouverte, on affiche la liste complète pour bien la valider visuellement.
+    if [[ $commits_in_advance_on_PR -gt 2 ]]; then
+        printf "%sLes commits suivants sont présents sur la branche %s%s%s actuelle mais pas sur la branche %s%s%s. Il seront repris sur la future branche %s%s%s%s\n" \
+        "$(tput setaf 2)"  \
+        "$(tput setaf 1)" "$branch_PR" "$(tput setaf 2)" \
+        "$(tput setaf 1)" "$reference_branch" "$(tput setaf 2)" \
+        "$(tput setaf 1)" "$branch_PR" "$(tput setaf 2)" \
+        "$(tput sgr0)"
+        for commit in "${commits_in_advance_on_PR[@]}"; do
+            get_commit_info "$commit"
+        done
+    fi
+
+    ###################################
+    # Gestion du rebase en cherrypick
+    ###################################
 
     # Lister les commits depuis le dernier commit d'init (dans l'ordre du plus ancien au plus récent)
     local commits=($(list_commits_since "$last_init_commit"))
@@ -84,9 +125,9 @@ feature_rebase() {
     git checkout $reference_branch --quiet
     git pull $j2s_remote $reference_branch --quiet
 
-    # rebase de la branche PR par application du commit d'init en cherry pick
+    # rebase de la branche PR par application des commit déjà présent sur l'ancienne branche PR en cherry pick
     checkout_or_create_branch $branch_PR_rebase
-    cherry_pick "$last_init_commit"
+    cherry_pick_commits "${commits_in_advance_on_PR[@]}"
 
     # rebase de la branche principal par application de tous les commits en cherry pick
     checkout_or_create_branch $branch_rebase

--- a/rebase.sh
+++ b/rebase.sh
@@ -14,6 +14,11 @@ feature_rebase() {
 
     git fetch $j2s_remote --quiet
 
+    git branch -D "$branch_rebase" --quiet 2>/dev/null
+    git branch -D $branch_PR_rebase --quiet 2>/dev/null
+    checkout_if_exists "$branch"
+    checkout_if_exists "$branch_PR"
+
     branch_in_remote=$(git ls-remote --heads ${j2s_remote} ${branch})
     branch_PR_in_remote=$(git ls-remote --heads ${j2s_remote} ${branch_PR})
     branch_in_local=$( git branch --list ${branch} )
@@ -58,31 +63,70 @@ feature_rebase() {
         exit_safe 1
     fi
 
+    # Lister les commits depuis le dernier commit d'init (dans l'ordre du plus ancien au plus récent)
+    local commits=($(list_commits_since "$last_init_commit"))
+
     #############################################################################
     # Cette partie permet de gérer le cas où la PR avait déjà été validée et mergée
     # puis réouverte par la suite, en effet dans ce cas là il y a déjà des commits 
     # présents sur la branche PR qui ne doivent pas être oubliés
     ##############################################################################
     
+    branches_have_same_code "$branch" "$branch_PR"
+
+    # Vérifier le résultat et afficher un message personnalisé
+    if [[ $? -eq 0 ]]; then
+        printf "\033[1;31mLe code sur la branche \033[1;32m%s\033[1;31m est parfaitement identique à celui sur la branche \033[1;32m%s\033[1;31m .\033[0m\n" "$branch" "$branch_PR" 
+        printf "Cette PRs a-t-elle déjà été cloturée ? Faut-il faire un restart ?\n"
+        printf "Ce rebase est bloqué pour éviter de fusiller des branches de PR après avoir mergée la PR.\n"
+        printf "Si vous êtes sur une feature toute neuve, poussez votre premier commit avant de rebase ou supprimez puis recréez.\n"
+
+        exit_safe 1
+    fi
+    
+    git checkout $branch_PR --quiet
+    
     # Récupérer la liste des commits en avance sur branch_PR
-    local commits_in_advance_on_PR=($(git rev-list "$reference_branch..$branch_PR"))
+    local commits_in_advance_on_PR=($(git rev-list "$reference_branch..$branch_PR" | tail -r))
 
-    # normalement le premier commit de la branche de travail et de la branche de PR doivent être les mêmes
-    # Si ce n'est pas les mêmes c'est pas normal on coupe le script.
-    if [[ "${commits_in_advance_on_PR[0]}" != $last_init_commit ]]; then
-        printf "%sLe premier commit de la branche %s%s%s est %s%s%s. Sur la branche %s%s%s il vaut %s%s%s, ce n'est pas normal%s\n" \
-        "$(tput setaf 2)"  \
-        "$(tput setaf 1)" "$branch_PR" "$(tput setaf 2)" \
-        "$(tput setaf 1)" "${commits_in_advance_on_PR[0]}" "$(tput setaf 2)" \
-        "$(tput setaf 1)" "$branch" "$(tput setaf 2)" \
-        "$(tput setaf 1)" "${last_init_commit[0]}" "$(tput setaf 2)" \
-        "$(tput sgr0)"
+    # Parcourir les commits de la branche feature et vérifier qu'ils ne sont pas pris en doublon dans la branche PR.
+    for item in "${commits[@]}"; do
+        if [[ " ${commits_in_advance_on_PR[@]} " =~ " $item " ]]; then
+            common_elements+=("$item")
+        fi
+    done
 
-        #exit_safe 0
+    # Afficher une erreur si des éléments communs sont trouvés
+    if [[ ${#common_elements[@]} -gt 0 ]]; then
+        printf "\033[1;31mErreur : Les commits suivants existent sur %s et %s, ce n'est pas normal :\033[0m\n" $branch $branch_PR
+        for commit in "${common_elements[@]}"; do
+            get_commit_info "$commit"
+        done
+        printf "\033[1;31mIl n'est pas possible de rebase une feature dont la PR a été cloturée. Peut-être faut-il la restart avant ?\033[0m\n"
+        exit_safe 1
     fi
 
-    # On est dans le cas d'une PR qui déjà été mergée puis réouverte, on affiche la liste complète pour bien la valider visuellement.
-    if [[ ${#commits_in_advance_on_PR[@]} -gt 1 ]]; then
+    # On ne peut pas automatiser un rebase s'il y a un commit de fusion, on refuse l'action
+    for commit in "${commits_in_advance_on_PR[@]}"; do
+        if is_merge_commit "$commit"; then
+            printf "\033[1;31mLe commit \033[1;32m%s\033[1;31m est un commit de fusion. On ne peut pas rebase automatiquement un commit de fusion.\033[0m\n" "$commit"  
+            printf "Il ne faut pas mélanger rebase et merge, la prochaine fois merci de ne faire que des rebases ;). Pensez à toujours squash and merge vos PRs"
+
+            exit_safe 1
+        fi
+    done
+
+    for commit in "${commits[@]}"; do
+        if is_merge_commit "$commit"; then
+            printf "\033[1;31mLe commit \033[1;32m%s\033[1;31m est un commit de fusion. On ne peut pas rebase automatiquement un commit de fusion.\033[0m\n" "$commit"  
+            printf "Il ne faut pas mélanger rebase et merge, la prochaine fois merci de ne faire que des rebases ;). Pensez à toujours squash and merge vos PRs"
+
+            exit_safe 1
+        fi
+    done
+
+    if [[ ${#commits_in_advance_on_PR[@]} -gt 0 ]]; then
+        # On est dans le cas d'une PR qui déjà été mergée puis réouverte, on affiche la liste complète pour bien la valider visuellement.
         printf "%sLes commits suivants sont présents sur la branche %s%s%s actuelle mais pas sur la branche %s%s%s. Il seront repris sur la future branche %s%s%s%s\n" \
         "$(tput setaf 2)"  \
         "$(tput setaf 1)" "$branch_PR" "$(tput setaf 2)" \
@@ -93,14 +137,12 @@ feature_rebase() {
             get_commit_info "$commit"
         done
     fi
-
+   
     ###################################
     # Gestion du rebase en cherrypick
     ###################################
 
-    # Lister les commits depuis le dernier commit d'init (dans l'ordre du plus ancien au plus récent)
-    local commits=($(list_commits_since "$last_init_commit"))
-
+    git checkout $branch --quiet
     printf "%sjgit va reprendre, dans l'ordre, tous les commits ci-dessous qui existe dans la branche locale %s%s%s\n" "$(tput setaf 2)" "$(tput setaf 1)" "$branch" "$(tput sgr0)"
     
     for commit in "${commits[@]}"; do
@@ -123,12 +165,14 @@ feature_rebase() {
     git pull $j2s_remote $reference_branch --quiet
 
     # rebase de la branche PR par application des commits déjà présents sur l'ancienne branche PR en cherry pick
+    echo "Starting cherry picking on $branch_PR_rebase branch"
     checkout_or_create_branch $branch_PR_rebase
     cherry_pick_commits "${commits_in_advance_on_PR[@]}"
 
     # rebase de la branche principal par application de tous les commits en cherry pick
+    echo "Starting cherry picking on $branch_PR_rebase branch"
     checkout_or_create_branch $branch_rebase
-    cherry_pick_commits "${commits[@]:1}" # On exclut le commit d'init qui a déjà été cherry-pick au dessus.  
+    cherry_pick_commits "${commits[@]}"
 
     # On vient écraser les branches historiques par les branches que l'on vient de rebase
     git checkout $reference_branch

--- a/rebase.sh
+++ b/rebase.sh
@@ -42,13 +42,13 @@ feature_rebase() {
     if [[ -z ${branch_in_local} ]]; then
         echo "$branch exists in remote but not in local"
         echo "Use remote branch"
-        git checkout -b $branch $j2s_remote/$branch
+        git checkout -b $branch $j2s_remote/$branch --quiet
     fi
 
     if [[ -z ${branch_PR_in_local} ]]; then
         echo "$branch_PR exists in remote but not in local"
         echo "Use remote branch"
-        git checkout -b $branch_PR $j2s_remote/$branch_PR
+        git checkout -b $branch_PR $j2s_remote/$branch_PR --quiet
     fi
 
     git checkout $branch --quiet

--- a/rebase.sh
+++ b/rebase.sh
@@ -40,14 +40,12 @@ feature_rebase() {
     fi
 
     if [[ -z ${branch_in_local} ]]; then
-        echo "$branch exists in remote but not in local"
-        echo "Use remote branch"
+        echo "$branch exists in remote but not in local, checkout from remote"
         git checkout -b $branch $j2s_remote/$branch --quiet
     fi
 
     if [[ -z ${branch_PR_in_local} ]]; then
-        echo "$branch_PR exists in remote but not in local"
-        echo "Use remote branch"
+        echo "$branch_PR exists in remote but not in local, checkout from remote"
         git checkout -b $branch_PR $j2s_remote/$branch_PR --quiet
     fi
 

--- a/rebase.sh
+++ b/rebase.sh
@@ -38,10 +38,10 @@ feature_rebase() {
 
     if [[ -z ${branch_in_remote} ]]; then
         echo "Something get wrong, $branch doesn't exist on remote"
-        exit_safe 0
+        exit_safe 1
     elif [[ -z ${branch_PR_in_remote} ]] ; then
         echo "Something get wrong, the branch $branch_PR doesn't exist on remote"
-        exit_safe 0
+        exit_safe 1
     fi
 
     if [[ -z ${branch_in_local} ]]; then

--- a/release.sh
+++ b/release.sh
@@ -8,7 +8,7 @@ source "$(dirname "$0")/functions.sh"
 release_start() {
     if [[ $(git status --porcelain) ]]; then
         echo "/!\ Local changes, cannot start release"
-        exit_safe 0;
+        exit_safe 1;
     fi
 
     git checkout $branch_prod
@@ -27,7 +27,7 @@ release_start() {
     else
         echo "A tag must already exists (x.x.x format)"
 
-        exit_safe 0
+        exit_safe 1
     fi
     feature=$(echo $feature + 1 | bc)
     future_tag="${major}.${feature}.${minor}"
@@ -81,7 +81,7 @@ release_merge() {
     if [[ $existed == 0 ]]; then
         echo "/!\ Feature branch was not found!"
 
-        exit_safe 0
+        exit_safe 1
     fi
 
    git push $j2s_remote ${release_branch}
@@ -118,7 +118,7 @@ release_finish() {
     if [[ $last_commit_message == "$prefix_init_commit release ${branch}. $suffix_init_commit" ]]; then
         echo "It seems that the release is empty..."
 
-        exit_safe 0;
+        exit_safe 1;
     fi
 
     if [[ $branch =~ $regex_branch ]]; then
@@ -128,7 +128,7 @@ release_finish() {
     else
         echo "Release branch seems to have a wrong format..."
 
-        exit_safe 0
+        exit_safe 1
     fi
 
     future_tag="${major}.${feature}.${minor}"

--- a/release.sh
+++ b/release.sh
@@ -69,13 +69,13 @@ release_merge() {
     if [[ ! -z ${existed_in_local} ]]; then
         echo "Feature branch exists on local machine, use it..."
         existed=1
-        git merge --no-ff ${branch} -m "$prefix_commit Merge feature branch : $branch $suffix_init_commit"
+        git merge --no-ff ${branch} -m "$prefix_commit Merge feature branch : $branch"
     fi
 
     if [[ ! -z ${existed_in_remote} && existed=0 ]]; then
         echo "Remote branch exists, use it..."
         existed=1
-        git merge --no-ff $j2s_remote/${branch} -m "$prefix_commit Merge feature branch : $branch $suffix_init_commit"
+        git merge --no-ff $j2s_remote/${branch} -m "$prefix_commit Merge feature branch : $branch"
     fi
 
     if [[ $existed == 0 ]]; then


### PR DESCRIPTION
Gestion de la réouverture de PR
On peut utiliser la fonction `jgit feature restart SWDEV-XXX` pour réouvrir une PR déjà mergée.
![image](https://github.com/user-attachments/assets/ebd02d39-bfb9-403d-b9ca-fe1083dc8ba0)
Cette PR réouverte peut etre rebase avec `jgit feature rebase SWDEV-XXX`

Lors d'un rebase, on garde l'historique des PRs déjà mergées
![image](https://github.com/user-attachments/assets/74efd41b-3885-4d61-9a59-2409775c9dbc)

Documentation mise à jour ici 
https://justsimplesolutions.atlassian.net/wiki/spaces/J2SIN/pages/4118904833/Utilisation+de+jGit#Restart---R%C3%A9-ouvrir-une-PR-d%C3%A9j%C3%A0-merg%C3%A9e




--------------

Amélioration 
1. Simplification de l'historique permettant la vérification sur la dernière étape pour n'afficher que les infos nécessaires
![image](https://github.com/user-attachments/assets/0ed035ca-8e16-4b8e-97c4-ac28288830c6)

2. JGit se remet sur la branche sur laquelle on se trouvait en fin de script

3. On peut utiliser le rebase pour changer la branche de base d'une feature : https://justsimplesolutions.atlassian.net/wiki/spaces/J2SIN/pages/4118904833/Utilisation+de+jGit#Est-ce-que-je-peux-utiliser-le-rebase-pour-change-ma-branche-d%E2%80%99origine-%3F