### PR TITLE
add_demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ jgit <scope> <action> [<target>] [options…]
 - `--from <branch>` : source d'un merge (option répétable).
 - `--into <branch>` : destination explicite du merge (sinon la branche courante est utilisée quand pertinent).
 - `--yes` : valide automatiquement toutes les confirmations.
-- `--dry-run` : affiche les actions prévues sans modifier votre dépôt ni contacter GitHub.
 - `--no-open` : n'ouvre pas automatiquement la PR lors d'un `feature/hotfix start` ou `restart`.
 - `jgit help` ou `jgit -h` : affiche l'aide détaillée.
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,53 @@
-## Project setup
+# J2S Git (`jgit`)
 
-### Installation
-First clone the repo
-```
-cd /path-to-your-j2sgit-project/
-git clone 
-```
+## Présentation
 
-### Add a jgit shortcut in your terminal
-Edit your zprofile
-```
-nano ~/.zprofile
-```
+`jgit` est un ensemble de scripts Bash destiné à automatiser les opérations Git quotidiennes au sein des projets J2S : création de branches, ouverture de pull requests, préparation de releases ou encore gestion de branches de démonstration. L'objectif est d'appliquer les conventions de l'équipe tout en limitant les erreurs manuelles.
 
-Add the line
-```
-alias jgit='/path-to-your-j2sgit-project/J2S-Git/jgit.sh'
-```
+## Installation
 
-Restart your terminal.
+1. Clonez ce dépôt dans le répertoire de votre choix :
+   ```bash
+   cd /chemin/vers/votre/espace-de-travail
+   git clone <url-du-repo-j2s-git>
+   ```
+2. Ajoutez un alias dans votre shell afin d'appeler `jgit` depuis n'importe quel projet.
+   - Sous macOS avec `zsh`, éditez `~/.zprofile` :
+     ```bash
+     nano ~/.zprofile
+     ```
+   - Ajoutez la ligne suivante en adaptant le chemin d'installation :
+     ```bash
+     alias jgit='/chemin/vers/J2S-git/jgit.sh'
+     ```
+   - Rechargez votre terminal ou exécutez `source ~/.zprofile`.
 
-### prerequisites
-You should have 1 remote named `origin` that head to a J2S github repository on all your local projects.
-You must have your reference branch existing on local (`develop2` or `master`)
+## Prérequis
 
-You must have git install on your local.
+- Un dépôt Git avec un remote nommé `origin` pointant vers GitHub (organisation J2S).
+- Git installé en local (`git --version` doit répondre).
+- Le client GitHub CLI (`gh`) installé et configuré : https://cli.github.com/
+- Un remote de référence (`develop`, `develop2`, `master`, `main`…) disponible en local.
 
-You must have github client install on your local https://cli.github.com/
+Configurez ensuite GitHub CLI sur chaque dépôt projet :
 
-Configure you gh envrionment
-
-```
+```bash
 gh repo set-default
 ```
 
-By default jgit use the following parameters
-```
+## Paramètres par défaut et surcharge locale
+
+Après installation, `jgit` utilise automatiquement :
+
+```bash
 j2s_remote="origin"
 branch_prod="main"
 branch_preprod="develop"
 ```
 
-You can ovveride those variable for each git projects by creating a specific configuration file.
+Pour adapter ces réglages à un projet précis, créez un fichier `.jgit/conf_local.sh` à la racine du dépôt (le dossier `.jgit` peut être ajouté à votre `.gitignore`). Exemple :
 
-In your git project, create a file `.jgit/conf_local.sh` (create the `.jgit` folder if needed)
-
-With the content (update with your needs)
-```
+```bash
 #!/bin/bash
 
 j2s_remote="origin"
@@ -54,14 +55,15 @@ branch_prod="master2"
 branch_preprod="develop2"
 ```
 
-PS : you can add `.jgit/*` in the .gitignore of your git project.
+Ce fichier sera automatiquement chargé par `jgit.sh` et aura priorité sur les valeurs par défaut.
 
-## Usage
-jgit se pilote directement depuis le dossier de votre projet :
+## Utilisation générale
 
-```
+Positionnez-vous dans un dépôt Git de projet :
+
+```bash
 cd /chemin/vers/mon-projet
-jgit <scope> <action> [<target>] [options…]
+jgit <scope> <action> [<cible>] [options...]
 ```
 
 ### Scopes disponibles
@@ -71,34 +73,36 @@ jgit <scope> <action> [<target>] [options…]
 - `demo`
 - `util`
 
-### Options communes
+### Options globales
 
-- `--based-on <branch>` : branche de référence lors d'un `start` ou d'un `rebase`.
-- `--from <branch>` : source d'un merge (option répétable).
-- `--into <branch>` : destination explicite du merge (sinon la branche courante est utilisée quand pertinent).
-- `--yes` : valide automatiquement toutes les confirmations.
-- `--no-open` : n'ouvre pas automatiquement la PR lors d'un `feature/hotfix start` ou `restart`.
-- `jgit help` ou `jgit -h` : affiche l'aide détaillée.
+- `--based-on <branche>` : force la branche de référence lors d'un `start` ou d'un `rebase`.
+- `--from <branche>` : ajoute une source à fusionner (option répétable).
+- `--into <branche>` : définit explicitement la branche de destination.
+- `--yes` (`-y`) : accepte toutes les confirmations.
+- `--no-open` : n'ouvre pas automatiquement la pull request lors d'un `start` ou `restart`.
+- `jgit help` / `jgit -h` : affiche l'aide complète.
+
+## Commandes par scope
 
 ### Feature & Hotfix
 
-- `jgit feature start <ticket> [--based-on <branch>] [--no-open]` — crée ou reprend `feature/<ticket>` ainsi que la branche PR `__PR__feature/<ticket>`. Une PR GitHub est ouverte sauf si `--no-open` est présent. Le comportement est identique avec `hotfix`.
-- `jgit feature restart <ticket> [--no-open]` — recrée `feature/<ticket>` depuis la branche PR après vérification du code. Supprime et repousse la branche de travail avant de rouvrir la PR (optionnellement sans l'ouvrir grâce à `--no-open`).
-- `jgit feature rebase <ticket> [--based-on <branch>]` — gère le rebase complet : vérifications, cherry-pick sur des branches temporaires `jgit_rebase_*`, renommage et force-push final. Disponible également pour `hotfix`.
+- `jgit feature start <ticket> [--based-on <branche>] [--no-open]` : crée ou reprend la branche `feature/<ticket>` et sa branche PR `__PR__feature/<ticket>`, pousse les commits d'initialisation et ouvre la PR (sauf `--no-open`). Identique avec `hotfix`.
+- `jgit feature restart <ticket> [--no-open]` : recrée la branche de travail depuis la branche PR après vérification de l'alignement du code, supprime l'ancienne branche distante et ré-ouvre la PR si nécessaire.
+- `jgit feature rebase <ticket> [--based-on <branche>]` : orchestre le rebase complet (branches temporaires `jgit_rebase_*`, cherry-pick, force-push final). Disponible également pour `hotfix`.
 
 ### Release
 
-- `jgit release start [<x.y.z>]` — sans cible, calcule le prochain numéro de version (`x.y.z`) à partir du dernier tag, crée ou reprend la branche `release/x.y.z` et pousse le commit d'initialisation. Avec une cible explicite, la branche `release/<x.y.z>` correspondante est préparée.
-- `jgit release merge [<x.y.z>] --from <branch> [--into <branch>]` — garantit que la branche de release est prête (création ou simple checkout) puis fusionne chaque branche listée avec `--from` dans la release. Les noms avec ou sans préfixe `__PR__` sont acceptés.
-- `jgit release finish [--into <release/x.y.z>]` — vérifie la cohérence de la release courante (ou de celle indiquée), fusionne dans `branch_prod`, crée le tag, supprime la branche de release localement/distante et génère la release GitHub.
+- `jgit release start [<x.y.z>]` : sans argument, calcule la prochaine version à partir du dernier tag, crée ou reprend `release/x.y.z` et pousse le commit initial. Avec `x.y.z`, prépare la branche correspondante.
+- `jgit release merge [<x.y.z>] --from <branche> [--into <branche>]` : s'assure que la branche de release est prête, puis fusionne en série chaque branche fournie avec `--from`. Les noms avec ou sans préfixe `__PR__` sont pris en charge.
+- `jgit release finish [--into <release/x.y.z>]` : vérifie la cohérence, fusionne sur la branche de production (`branch_prod`), crée le tag, supprime la branche de release en local/distante et génère la release GitHub.
 
 ### Demo
 
-- `jgit demo start [<demo_name>] [--based-on <branch>]` — prépare une branche `demo_<nom>` existante (checkout + fast-forward) ou en crée une nouvelle basée sur la branche fournie, après confirmation.
-- `jgit demo merge [--into <demo_branch>] --from feature/<ticket> [--from hotfix/<ticket>]…` — merge en série chaque branche fournie dans la démo cible (branche courante par défaut). La branche est tenue linéaire via rebase et `--force-with-lease`.
-- `jgit demo list` — liste les marqueurs `[jgit] DEMO …` depuis le commit d'initialisation, affiche les branches fusionnées et suggère les commandes `jgit release merge --from …` correspondantes.
-- `jgit demo remove [--yes]` — après confirmation, supprime la branche de démo sur le remote puis en local et vous replace sur la branche de référence.
+- `jgit demo start [<nom_demo>] [--based-on <branche>]` : prépare une branche `demo_<nom>` existante (checkout + fast-forward) ou en crée une nouvelle à partir de la branche fournie après confirmation.
+- `jgit demo merge [--into <branche_demo>] --from feature/<ticket> [--from hotfix/<ticket>]...` : fusionne successivement chaque branche listée dans la démo cible (branche courante par défaut) en conservant un historique linéaire.
+- `jgit demo list` : parcourt les commits `[jgit] DEMO …`, affiche les branches déjà fusionnées et suggère les commandes `jgit release merge --from ...` correspondantes.
+- `jgit demo remove [--yes]` : supprime la branche de démonstration sur le remote puis en local, et replace l'utilisateur sur la branche de référence.
 
-### Utility
+### Utilitaires
 
-- `jgit util clean` — supprime les branches locales temporaires utilisées par jgit (`jgit_rebase_*`, `__PR__*`).
+- `jgit util clean` : supprime les branches locales temporaires créées par `jgit` (`jgit_rebase_*`, `__PR__*`).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ gh repo set-default
 
 By default jgit use the following parameters
 ```
-2s_remote="origin"
+j2s_remote="origin"
 branch_prod="main"
 branch_preprod="develop"
 ```
@@ -57,36 +57,49 @@ branch_preprod="develop2"
 PS : you can add `.jgit/*` in the .gitignore of your git project.
 
 ## Usage
-jgit will be used in command line directly from your project folder.
+jgit se pilote directement depuis le dossier de votre projet :
 
-Example
 ```
-toto@MacBook-Pro ~ % cd Projets/My-project 
-toto@MacBook-Pro % jgit feature start TESTDEV-1111
+cd /chemin/vers/mon-projet
+jgit <scope> <action> [<target>] [options…]
 ```
 
-Please read the documentation with `jgit -h` or `jgit help`
+### Scopes disponibles
 
-### Feature & Hotfix commands
+- `feature` / `hotfix`
+- `release`
+- `demo`
+- `util`
 
-- `jgit feature start <ticket> [--based-on <branch>]` — creates (or resumes) the working branch `feature/<ticket>` and its PR branch `__PR__feature/<ticket>`. When the branches do not exist yet, the reference branch is checked out (`--based-on` or default), a commit is added to seed the PR, everything is pushed, and a GitHub PR is opened. Replace `feature` with `hotfix` for an identical workflow on hotfix branches.
-- `jgit feature restart <ticket>` — resets the working branch from the existing PR branch after verifying that both hold the same code. The script deletes the old `feature/<ticket>` locally/remotely, recreates it with a restart marker commit, pushes it, and reopens the PR. Also available as `jgit hotfix restart`.
-- `jgit feature rebase <ticket> [--based-on <branch>]` — orchestrates a clean rebase: fetches the remote branches, ensures no merge commits slip in, displays the commits to replay, cherry-picks them onto temporary `jgit_rebase_*` branches, renames them back, and force-pushes. Works the same for `jgit hotfix rebase`.
+### Options communes
 
-### Release commands
+- `--based-on <branch>` : branche de référence lors d'un `start` ou d'un `rebase`.
+- `--from <branch>` : source d'un merge (option répétable).
+- `--into <branch>` : destination explicite du merge (sinon la branche courante est utilisée quand pertinent).
+- `--yes` : valide automatiquement toutes les confirmations.
+- `--dry-run` : affiche les actions prévues sans modifier votre dépôt ni contacter GitHub.
+- `--no-open` : n'ouvre pas automatiquement la PR lors d'un `feature/hotfix start` ou `restart`.
+- `jgit help` ou `jgit -h` : affiche l'aide détaillée.
 
-- `jgit release start` — inspects the latest `x.y.z` tag, increments the middle number, and creates or resumes the corresponding `release/x.y.z` branch with an init commit.
-- `jgit release merge <branch>` — ensures the release branch is ready (creating it if needed) then merges the provided branch (usually `__PR__feature/<ticket>`) into the release, preferring a local branch if present otherwise the remote one.
-- `jgit release finish` — validates the current release branch, merges it into `main` (`branch_prod`), tags the release, deletes the release branch locally/remotely, pushes, and creates a GitHub release.
+### Feature & Hotfix
 
-### Demo commands
+- `jgit feature start <ticket> [--based-on <branch>] [--no-open]` — crée ou reprend `feature/<ticket>` ainsi que la branche PR `__PR__feature/<ticket>`. Une PR GitHub est ouverte sauf si `--no-open` est présent. Le comportement est identique avec `hotfix`.
+- `jgit feature restart <ticket> [--no-open]` — recrée `feature/<ticket>` depuis la branche PR après vérification du code. Supprime et repousse la branche de travail avant de rouvrir la PR (optionnellement sans l'ouvrir grâce à `--no-open`).
+- `jgit feature rebase <ticket> [--based-on <branch>]` — gère le rebase complet : vérifications, cherry-pick sur des branches temporaires `jgit_rebase_*`, renommage et force-push final. Disponible également pour `hotfix`.
 
-- `jgit demo start [demo_name] [--based-on <branch>]` — creates or resumes a `demo_<base>` branch. Existing branches are checked out and fast-forwarded; otherwise the branch is created from the chosen reference branch after confirmation and pushed with a marker commit.
-- `jgit demo merge feature <feature_name>` — run from a demo branch. Checks that `feature/<feature_name>` exists on the remote, adds a marker commit if missing, applies the feature commits onto the demo branch, and pushes with `--force-with-lease` to keep the history linear.
-- `jgit demo list` — scans the history since the demo init commit, finds all `[jgit] DEMO feature …` markers, and prints both the merged features and the `jgit release merge` commands to replay them during a release.
-- `jgit demo remove` — from a demo branch, asks for confirmation, switches back to the reference branch, deletes the demo branch on the remote then locally, and leaves you on the safe branch.
+### Release
+
+- `jgit release start [<x.y.z>]` — sans cible, calcule le prochain numéro de version (`x.y.z`) à partir du dernier tag, crée ou reprend la branche `release/x.y.z` et pousse le commit d'initialisation. Avec une cible explicite, la branche `release/<x.y.z>` correspondante est préparée.
+- `jgit release merge [<x.y.z>] --from <branch> [--into <branch>]` — garantit que la branche de release est prête (création ou simple checkout) puis fusionne chaque branche listée avec `--from` dans la release. Les noms avec ou sans préfixe `__PR__` sont acceptés.
+- `jgit release finish [--into <release/x.y.z>]` — vérifie la cohérence de la release courante (ou de celle indiquée), fusionne dans `branch_prod`, crée le tag, supprime la branche de release localement/distante et génère la release GitHub.
+
+### Demo
+
+- `jgit demo start [<demo_name>] [--based-on <branch>]` — prépare une branche `demo_<nom>` existante (checkout + fast-forward) ou en crée une nouvelle basée sur la branche fournie, après confirmation.
+- `jgit demo merge [--into <demo_branch>] --from feature/<ticket> [--from hotfix/<ticket>]…` — merge en série chaque branche fournie dans la démo cible (branche courante par défaut). La branche est tenue linéaire via rebase et `--force-with-lease`.
+- `jgit demo list` — liste les marqueurs `[jgit] DEMO …` depuis le commit d'initialisation, affiche les branches fusionnées et suggère les commandes `jgit release merge --from …` correspondantes.
+- `jgit demo remove [--yes]` — après confirmation, supprime la branche de démo sur le remote puis en local et vous replace sur la branche de référence.
 
 ### Utility
 
-- `jgit clean` — removes local helper branches created by jgit (`jgit_rebase_*`, `__PR__*`).
-- `jgit help` ou `jgit -h` — displays the in-terminal help with every command and option.
+- `jgit util clean` — supprime les branches locales temporaires utilisées par jgit (`jgit_rebase_*`, `__PR__*`).

--- a/README.md
+++ b/README.md
@@ -66,3 +66,27 @@ toto@MacBook-Pro % jgit feature start TESTDEV-1111
 ```
 
 Please read the documentation with `jgit -h` or `jgit help`
+
+### Feature & Hotfix commands
+
+- `jgit feature start <ticket> [--based-on <branch>]` — creates (or resumes) the working branch `feature/<ticket>` and its PR branch `__PR__feature/<ticket>`. When the branches do not exist yet, the reference branch is checked out (`--based-on` or default), a commit is added to seed the PR, everything is pushed, and a GitHub PR is opened. Replace `feature` with `hotfix` for an identical workflow on hotfix branches.
+- `jgit feature restart <ticket>` — resets the working branch from the existing PR branch after verifying that both hold the same code. The script deletes the old `feature/<ticket>` locally/remotely, recreates it with a restart marker commit, pushes it, and reopens the PR. Also available as `jgit hotfix restart`.
+- `jgit feature rebase <ticket> [--based-on <branch>]` — orchestrates a clean rebase: fetches the remote branches, ensures no merge commits slip in, displays the commits to replay, cherry-picks them onto temporary `jgit_rebase_*` branches, renames them back, and force-pushes. Works the same for `jgit hotfix rebase`.
+
+### Release commands
+
+- `jgit release start` — inspects the latest `x.y.z` tag, increments the middle number, and creates or resumes the corresponding `release/x.y.z` branch with an init commit.
+- `jgit release merge <branch>` — ensures the release branch is ready (creating it if needed) then merges the provided branch (usually `__PR__feature/<ticket>`) into the release, preferring a local branch if present otherwise the remote one.
+- `jgit release finish` — validates the current release branch, merges it into `main` (`branch_prod`), tags the release, deletes the release branch locally/remotely, pushes, and creates a GitHub release.
+
+### Demo commands
+
+- `jgit demo start [demo_name] [--based-on <branch>]` — creates or resumes a `demo_<base>` branch. Existing branches are checked out and fast-forwarded; otherwise the branch is created from the chosen reference branch after confirmation and pushed with a marker commit.
+- `jgit demo merge feature <feature_name>` — run from a demo branch. Checks that `feature/<feature_name>` exists on the remote, adds a marker commit if missing, applies the feature commits onto the demo branch, and pushes with `--force-with-lease` to keep the history linear.
+- `jgit demo list` — scans the history since the demo init commit, finds all `[jgit] DEMO feature …` markers, and prints both the merged features and the `jgit release merge` commands to replay them during a release.
+- `jgit demo remove` — from a demo branch, asks for confirmation, switches back to the reference branch, deletes the demo branch on the remote then locally, and leaves you on the safe branch.
+
+### Utility
+
+- `jgit clean` — removes local helper branches created by jgit (`jgit_rebase_*`, `__PR__*`).
+- `jgit help` ou `jgit -h` — displays the in-terminal help with every command and option.

--- a/demo.sh
+++ b/demo.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+source "$(dirname "$0")/functions.sh"
+
+DemoBranchPrefix="demo_"
+
+get_demo_branch_name() {
+    local suffix="$1"
+    echo "${DemoBranchPrefix}${suffix}"
+}
+
+is_demo_branch() {
+    local branch="$1"
+    [[ "$branch" == ${DemoBranchPrefix}* ]]
+}
+
+demo_start() {
+    local requested_name="$1"
+    local based_on="$2"
+    local current_local_branch=$(git rev-parse --abbrev-ref HEAD)
+
+    local base_branch
+    if [[ -n "$based_on" ]]; then
+        base_branch="$based_on"
+    else
+        base_branch=$(get_reference_branch)
+    fi
+
+    if [[ -z "$base_branch" ]]; then
+        echo "Impossible de déterminer la branche de référence pour la démo."
+        exit_safe 1
+    fi
+
+    if [[ -z "$requested_name" ]]; then
+        requested_name="$base_branch"
+    fi
+
+    local demo_branch
+    demo_branch=$(get_demo_branch_name "$requested_name")
+
+    git fetch "$j2s_remote" --quiet
+
+    local remote_exists
+    remote_exists=$(git ls-remote --heads "$j2s_remote" "$demo_branch")
+
+    if [[ -n "$remote_exists" ]]; then
+        if git show-ref --verify --quiet "refs/heads/$demo_branch"; then
+            git checkout "$demo_branch" --quiet
+            if ! git pull --ff-only "$j2s_remote" "$demo_branch"; then
+                printf "\033[1;31mLa branche locale %s est en conflit avec %s/%s\033[0m\n" "$demo_branch" "$j2s_remote" "$demo_branch"
+                printf "Veuillez résoudre manuellement la divergence avant de relancer la commande.\n"
+                exit_safe 1
+            fi
+        else
+            git checkout -b "$demo_branch" "$j2s_remote/$demo_branch" --quiet
+            git pull --ff-only "$j2s_remote" "$demo_branch" --quiet
+        fi
+        current_branch="$demo_branch"
+        printf "Branche %s prête pour la démo.\n" "$demo_branch"
+        exit_safe 0
+    fi
+
+    if git show-ref --verify --quiet "refs/heads/$demo_branch"; then
+        printf "\033[1;31mLa branche %s existe en local mais pas sur %s.\033[0m\n" "$demo_branch" "$j2s_remote"
+        printf "Veuillez la publier manuellement ou la supprimer avant de relancer la commande.\n"
+        exit_safe 1
+    fi
+
+    if ! git show-ref --verify --quiet "refs/heads/$base_branch"; then
+        if git ls-remote --heads "$j2s_remote" "$base_branch" >/dev/null 2>&1; then
+            git fetch "$j2s_remote" "$base_branch:$base_branch" --quiet
+        else
+            printf "\033[1;31mLa branche de référence %s est introuvable en local ou sur %s.\033[0m\n" "$base_branch" "$j2s_remote"
+            exit_safe 1
+        fi
+    fi
+
+    printf "%sJGit va créer la branche de démo %s%s%s%s qui se basera sur la branche %s%s%s\n" \
+    "$(tput setaf 2)" "$(tput setaf 1)" "$demo_branch" "$(tput sgr0)"  "$(tput setaf 2)" "$(tput setaf 1)" "$base_branch" "$(tput sgr0)"
+    # Demander confirmation à l'utilisateur
+    read -p "Souhaitez-vous continuer ? (y/n) " user_input
+    if [[ "$user_input" != "y" ]]; then
+        echo "Opération annulée."
+        exit_safe 1
+    fi
+
+    checkout_if_exists "$base_branch"
+    git checkout -b "$demo_branch" --quiet
+    git commit --allow-empty -m "$prefix_init_commit demo $demo_branch $suffix_init_commit" --quiet
+    git push --set-upstream "$j2s_remote" "$demo_branch" --quiet
+
+    current_branch="$demo_branch"
+    printf "Branche %s créée depuis %s et publiée avec succès.\n" "$demo_branch" "$base_branch"
+    exit_safe 0
+}
+
+demo_merge_feature() {
+    local feature_name="$1"
+    if [[ -z "$feature_name" ]]; then
+        echo "Veuillez indiquer le nom de la feature à merger."
+        exit_safe 1
+    fi
+
+    local feature_branch="feature/$feature_name"
+    local demo_branch=$(git rev-parse --abbrev-ref HEAD)
+
+    if ! is_demo_branch "$demo_branch"; then
+        printf "\033[1;31mCette commande doit être exécutée depuis une branche demo_*.\033[0m\n"
+        exit_safe 1
+    fi
+
+    git fetch "$j2s_remote" --quiet
+
+    if ! git ls-remote --exit-code --heads "$j2s_remote" "$feature_branch" >/dev/null 2>&1; then
+        printf "\033[1;31mLa branche %s n'existe pas sur %s.\033[0m\n" "$feature_branch" "$j2s_remote"
+        exit_safe 1
+    fi
+
+    if ! git pull --ff-only "$j2s_remote" "$demo_branch"; then
+        printf "\033[1;31mImpossible de mettre à jour %s depuis %s/%s.\033[0m\n" "$demo_branch" "$j2s_remote" "$demo_branch"
+        printf "Veuillez résoudre la divergence puis relancer la commande.\n"
+        exit_safe 1
+    fi
+
+    if git merge-base --is-ancestor "$j2s_remote/$feature_branch" HEAD; then
+        printf "La feature %s est déjà présente dans %s.\n" "$feature_branch" "$demo_branch"
+        exit_safe 0
+    fi
+
+    local marker_message="$prefix_commit DEMO feature $feature_branch $suffix_init_commit"
+
+    if git log --pretty=format:"%s" | grep -Fq "$marker_message"; then
+        printf "Un marqueur pour %s existe déjà.\n" "$feature_branch"
+    else
+        git commit --allow-empty -m "$marker_message" --quiet
+    fi
+
+    if ! git rebase "$j2s_remote/$feature_branch"; then
+        printf "\033[1;31mRebase interrompu pour %s. Résolvez les conflits puis terminez le rebase manuellement.\033[0m\n" "$feature_branch"
+        printf "Utilisez 'git rebase --continue' après résolution ou 'git rebase --abort' pour annuler.\n"
+        exit_safe 1
+    fi
+
+
+    git push --force-with-lease "$j2s_remote" "$demo_branch"
+    printf "Feature %s rebase avec succès dans %s.\n" "$feature_branch" "$demo_branch"
+    exit_safe 0
+}
+
+demo_list() {
+    local demo_branch=$(git rev-parse --abbrev-ref HEAD)
+
+    if ! is_demo_branch "$demo_branch"; then
+        printf "\033[1;31mCette commande doit être exécutée depuis une branche demo_*.\033[0m\n"
+        exit_safe 1
+    fi
+
+    git fetch "$j2s_remote" --quiet
+    git pull --ff-only "$j2s_remote" "$demo_branch" >/dev/null 2>&1
+
+    local init_commit
+    init_commit=$(get_last_commit_with_pattern "$prefix_init_commit demo $demo_branch")
+
+    if [[ -z "$init_commit" ]]; then
+        printf "\033[1;31mImpossible de trouver le commit d'initialisation de la démo.\033[0m\n"
+        exit_safe 1
+    fi
+
+    local entries=()
+    local log_output
+    log_output=$(git log --reverse --pretty=format:"%H%-_-_-%s" "$init_commit^..HEAD")
+
+    while IFS=$'-_-_-' read -r commit_hash commit_subject; do
+        if [[ "$commit_subject" == *"DEMO feature "* ]]; then
+            local feature_branch
+            feature_branch=$(echo "$commit_subject" | awk '{print $4}')
+            if [[ -n "$feature_branch" ]]; then
+                entries+=("$feature_branch")
+            fi
+        fi
+    done <<< "$log_output"
+
+    if [[ ${#entries[@]} -eq 0 ]]; then
+        printf "Aucune feature mergée détectée pour %s.\n" "$demo_branch"
+        exit_safe 0
+    fi
+
+    local color_title=$(tput bold; tput setaf 6)
+    local color_feature=$(tput setaf 2)
+    local color_marker=$(tput setaf 4)
+    local color_reset=$(tput sgr0)
+
+    printf "%sFeatures mergées dans %s :%s\n" "$color_title" "$demo_branch" "$color_reset"
+    for feature_branch in "${entries[@]}"; do
+        local feature_name=${feature_branch#feature/}
+        printf "  %s-%s %s (%s%s%s)\n" "$color_feature" "$color_reset" "$feature_name" "$color_marker" "$feature_branch" "$color_reset"
+    done
+    printf "\n%sCommandes release à exécuter :%s\n" "$color_title" "$color_reset"
+    for feature_branch in "${entries[@]}"; do
+        printf "jgit release merge %s\n" "$feature_branch"
+    done
+    printf "\n"
+
+    exit_safe 0
+}
+
+demo_remove() {
+    local demo_branch=$(git rev-parse --abbrev-ref HEAD)
+
+    if ! is_demo_branch "$demo_branch"; then
+        printf "\033[1;31mCette commande doit être exécutée depuis une branche demo_*.\033[0m\n"
+        exit_safe 1
+    fi
+
+    git fetch "$j2s_remote" --quiet
+
+    local reference_branch
+    reference_branch=$(get_reference_branch "feature")
+
+    local color_title=$(tput bold; tput setaf 6)
+    local color_branch=$(tput bold; tput setaf 1)
+    local color_text=$(tput setaf 2)
+    local color_reset=$(tput sgr0)
+
+    printf "%sSuppression de la branche de démo %s%s%s%s\n" \
+        "$color_title" "$color_branch" "$demo_branch" "$color_title" "$color_reset"
+    printf "%sElle sera retirée du remote %s%s%s et supprimée en local.%s\n" \
+        "$color_text" "$color_branch" "$j2s_remote" "$color_text" "$color_reset"
+
+    read -p "Confirmez-vous la suppression ? (y/n) " user_input
+    if [[ "$user_input" != "y" ]]; then
+        echo "Opération annulée."
+        exit_safe 1
+    fi
+
+    checkout_if_exists "$reference_branch"
+
+    if git ls-remote --exit-code --heads "$j2s_remote" "$demo_branch" >/dev/null 2>&1; then
+        if ! git push "$j2s_remote" --delete "$demo_branch"; then
+            printf "\033[1;31mImpossible de supprimer %s sur %s.\033[0m\n" "$demo_branch" "$j2s_remote"
+            exit_safe 1
+        fi
+    else
+        printf "%sAucune branche distante %s%s%s trouvée.%s\n" \
+            "$color_text" "$color_branch" "$demo_branch" "$color_text" "$color_reset"
+    fi
+
+    if git show-ref --verify --quiet "refs/heads/$demo_branch"; then
+        git branch -D "$demo_branch"
+    fi
+
+    current_branch="$reference_branch"
+    printf "%sBranche de démo supprimée avec succès.%s\n" "$color_text" "$color_reset"
+    exit_safe 0
+}

--- a/demo.sh
+++ b/demo.sh
@@ -16,6 +16,7 @@ is_demo_branch() {
 demo_start() {
     local requested_name="$1"
     local based_on="$2"
+    local _unused_into="$3"
     local current_local_branch=$(git rev-parse --abbrev-ref HEAD)
 
     local base_branch
@@ -77,8 +78,7 @@ demo_start() {
     printf "%sJGit va créer la branche de démo %s%s%s%s qui se basera sur la branche %s%s%s\n" \
     "$(tput setaf 2)" "$(tput setaf 1)" "$demo_branch" "$(tput sgr0)"  "$(tput setaf 2)" "$(tput setaf 1)" "$base_branch" "$(tput sgr0)"
     # Demander confirmation à l'utilisateur
-    read -p "Souhaitez-vous continuer ? (y/n) " user_input
-    if [[ "$user_input" != "y" ]]; then
+    if ! confirm_action "Souhaitez-vous continuer ?" "y"; then
         echo "Opération annulée."
         exit_safe 1
     fi
@@ -93,27 +93,36 @@ demo_start() {
     exit_safe 0
 }
 
-demo_merge_feature() {
-    local feature_name="$1"
-    if [[ -z "$feature_name" ]]; then
-        echo "Veuillez indiquer le nom de la feature à merger."
+resolve_demo_source_branch() {
+    local source="$1"
+    if [[ "$source" == feature/* || "$source" == hotfix/* ]]; then
+        echo "$source"
+    else
+        printf "\033[1;31mLe format attendu est feature/<ticket> ou hotfix/<ticket>.\033[0m\n"
         exit_safe 1
     fi
+}
 
-    local feature_branch="feature/$feature_name"
-    local demo_branch=$(git rev-parse --abbrev-ref HEAD)
+demo_merge_branch() {
+    local source_branch
+    source_branch=$(resolve_demo_source_branch "$1")
+    local demo_branch="$2"
+
+    local source_remote="$j2s_remote/$source_branch"
 
     if ! is_demo_branch "$demo_branch"; then
-        printf "\033[1;31mCette commande doit être exécutée depuis une branche demo_*.\033[0m\n"
+        printf "\033[1;31mCette commande doit être exécutée sur une branche demo_* (branche actuelle : %s).\033[0m\n" "$demo_branch"
         exit_safe 1
     fi
 
     git fetch "$j2s_remote" --quiet
 
-    if ! git ls-remote --exit-code --heads "$j2s_remote" "$feature_branch" >/dev/null 2>&1; then
-        printf "\033[1;31mLa branche %s n'existe pas sur %s.\033[0m\n" "$feature_branch" "$j2s_remote"
+    if ! git ls-remote --exit-code --heads "$j2s_remote" "$source_branch" >/dev/null 2>&1; then
+        printf "\033[1;31mLa branche %s n'existe pas sur %s.\033[0m\n" "$source_branch" "$j2s_remote"
         exit_safe 1
     fi
+
+    git checkout "$demo_branch" --quiet
 
     if ! git pull --ff-only "$j2s_remote" "$demo_branch"; then
         printf "\033[1;31mImpossible de mettre à jour %s depuis %s/%s.\033[0m\n" "$demo_branch" "$j2s_remote" "$demo_branch"
@@ -121,29 +130,52 @@ demo_merge_feature() {
         exit_safe 1
     fi
 
-    if git merge-base --is-ancestor "$j2s_remote/$feature_branch" HEAD; then
-        printf "La feature %s est déjà présente dans %s.\n" "$feature_branch" "$demo_branch"
-        exit_safe 0
+    if git merge-base --is-ancestor "$source_remote" HEAD; then
+        printf "La branche %s est déjà présente dans %s.\n" "$source_branch" "$demo_branch"
+        return 0
     fi
 
-    local marker_message="$prefix_commit DEMO feature $feature_branch $suffix_init_commit"
+    local branch_type="${source_branch%%/*}"
+    local marker_message="$prefix_commit DEMO merge $branch_type $source_branch $suffix_init_commit"
 
     if git log --pretty=format:"%s" | grep -Fq "$marker_message"; then
-        printf "Un marqueur pour %s existe déjà.\n" "$feature_branch"
+        printf "Un marqueur pour %s existe déjà.\n" "$source_branch"
     else
         git commit --allow-empty -m "$marker_message" --quiet
     fi
 
-    if ! git rebase "$j2s_remote/$feature_branch"; then
-        printf "\033[1;31mRebase interrompu pour %s. Résolvez les conflits puis terminez le rebase manuellement.\033[0m\n" "$feature_branch"
+    if ! git rebase "$source_remote"; then
+        printf "\033[1;31mRebase interrompu pour %s. Résolvez les conflits puis terminez le rebase manuellement.\033[0m\n" "$source_branch"
         printf "Utilisez 'git rebase --continue' après résolution ou 'git rebase --abort' pour annuler.\n"
         exit_safe 1
     fi
 
-
     git push --force-with-lease "$j2s_remote" "$demo_branch"
-    printf "Feature %s rebase avec succès dans %s.\n" "$feature_branch" "$demo_branch"
-    exit_safe 0
+    printf "Branche %s rebasée avec succès dans %s.\n" "$source_branch" "$demo_branch"
+}
+
+demo_merge() {
+    local target_branch="$1"
+    shift || true
+    local sources=("$@")
+
+    if [[ -z "$target_branch" ]]; then
+        target_branch=$(git rev-parse --abbrev-ref HEAD)
+    else
+        if [[ "$target_branch" != ${DemoBranchPrefix}* ]]; then
+            target_branch=$(get_demo_branch_name "$target_branch")
+        fi
+        checkout_if_exists "$target_branch"
+    fi
+
+    if [[ ${#sources[@]} -eq 0 ]]; then
+        echo "Veuillez préciser au moins une source avec --from." >&2
+        exit_safe 1
+    fi
+
+    for source in "${sources[@]}"; do
+        demo_merge_branch "$source" "$target_branch"
+    done
 }
 
 demo_list() {
@@ -170,17 +202,14 @@ demo_list() {
     log_output=$(git log --reverse --pretty=format:"%H%-_-_-%s" "$init_commit^..HEAD")
 
     while IFS=$'-_-_-' read -r commit_hash commit_subject; do
-        if [[ "$commit_subject" == *"DEMO feature "* ]]; then
-            local feature_branch
-            feature_branch=$(echo "$commit_subject" | awk '{print $4}')
-            if [[ -n "$feature_branch" ]]; then
-                entries+=("$feature_branch")
-            fi
+        read -r first_word second_word branch_type branch_name _ <<< "$commit_subject"
+        if [[ "$second_word" == "DEMO" && -n "$branch_type" && -n "$branch_name" ]]; then
+            entries+=("$branch_type:$branch_name")
         fi
     done <<< "$log_output"
 
     if [[ ${#entries[@]} -eq 0 ]]; then
-        printf "Aucune feature mergée détectée pour %s.\n" "$demo_branch"
+        printf "Aucune branche mergée détectée pour %s.\n" "$demo_branch"
         exit_safe 0
     fi
 
@@ -189,14 +218,17 @@ demo_list() {
     local color_marker=$(tput setaf 4)
     local color_reset=$(tput sgr0)
 
-    printf "%sFeatures mergées dans %s :%s\n" "$color_title" "$demo_branch" "$color_reset"
-    for feature_branch in "${entries[@]}"; do
-        local feature_name=${feature_branch#feature/}
-        printf "  %s-%s %s (%s%s%s)\n" "$color_feature" "$color_reset" "$feature_name" "$color_marker" "$feature_branch" "$color_reset"
+    printf "%sBranches mergées dans %s :%s\n" "$color_title" "$demo_branch" "$color_reset"
+    for entry in "${entries[@]}"; do
+        local branch_type=${entry%%:*}
+        local branch_name=${entry#*:}
+        local short_name=${branch_name#${branch_type}/}
+        printf "  %s-%s %s (%s%s%s)\n" "$color_feature" "$color_reset" "$short_name" "$color_marker" "$branch_name" "$color_reset"
     done
-    printf "\n%sCommandes release à exécuter :%s\n" "$color_title" "$color_reset"
-    for feature_branch in "${entries[@]}"; do
-        printf "jgit release merge %s\n" "$feature_branch"
+    printf "\n%sCommandes release suggérées :%s\n" "$color_title" "$color_reset"
+    for entry in "${entries[@]}"; do
+        local branch_name=${entry#*:}
+        printf "jgit release merge --from %s\n" "$branch_name"
     done
     printf "\n"
 
@@ -226,8 +258,7 @@ demo_remove() {
     printf "%sElle sera retirée du remote %s%s%s et supprimée en local.%s\n" \
         "$color_text" "$color_branch" "$j2s_remote" "$color_text" "$color_reset"
 
-    read -p "Confirmez-vous la suppression ? (y/n) " user_input
-    if [[ "$user_input" != "y" ]]; then
+    if ! confirm_action "Confirmez-vous la suppression ?" "y"; then
         echo "Opération annulée."
         exit_safe 1
     fi

--- a/feature.sh
+++ b/feature.sh
@@ -41,8 +41,7 @@ feature_start() {
         printf "%sJGit va créer la branche %s%s%s%s et sa PR associée qui se basera sur la branche %s%s%s\n" \
         "$(tput setaf 2)" "$(tput setaf 1)" "$branch" "$(tput sgr0)"  "$(tput setaf 2)" "$(tput setaf 1)" "$reference_branch" "$(tput sgr0)"
         # Demander confirmation à l'utilisateur
-        read -p "Souhaitez-vous continuer ? (y/n) " user_input
-        if [[ "$user_input" != "y" ]]; then
+        if ! confirm_action "Souhaitez-vous continuer ?" "y"; then
             echo "Opération annulée."
             exit_safe 1
         fi
@@ -59,8 +58,12 @@ feature_start() {
         git push --set-upstream $j2s_remote $branch --quiet
         current_branch="$branch"
         git branch -D $branch_PR --quiet
-        echo "Create pull request"
-        gh pr create --title $feature_name --body "https://justsimplesolutions.atlassian.net/browse/"$feature_name --base=$branch_PR --head=$branch --label "NFR"
+        if [[ $JGIT_NO_OPEN == true ]]; then
+            echo "Skipping pull request creation (--no-open)."
+        else
+            echo "Create pull request"
+            gh pr create --title "$feature_name" --body "https://justsimplesolutions.atlassian.net/browse/$feature_name" --base=$branch_PR --head=$branch --label "NFR"
+        fi
     else
         echo "On est dans la Matrix"
     fi
@@ -75,7 +78,7 @@ feature_restart() {
     local branch_PR=$prefix_PR$branch
 
     # Vérifier si la branche référence existe
-    if ! git rev-parse --verify "$branch_PR" >/dev/null 2>&1 && ! git ls-remote --heads origin "$branch_PR" >/dev/null 2>&1; then
+    if ! git rev-parse --verify "$branch_PR" >/dev/null 2>&1 && ! git ls-remote --heads "$j2s_remote" "$branch_PR" >/dev/null 2>&1; then
         echo "Erreur : La branche de PR '$branch_PR' n'existe pas."
         exit_safe 1
     fi
@@ -106,7 +109,7 @@ feature_restart() {
     git branch -d "$branch" 2>/dev/null
   
     # Suppression de la branche sur le remote - on ignore l'erreur si elle n'existe déjà pas
-    git push origin --delete "$branch" 2>/dev/null
+    git push "$j2s_remote" --delete "$branch" 2>/dev/null
 
     echo "Create working branch $branch"
     git checkout -b $branch --quiet
@@ -114,6 +117,10 @@ feature_restart() {
     git push --set-upstream $j2s_remote $branch --quiet
     current_branch="$branch"
     git branch -D $branch_PR --quiet
-    echo "Create pull request"
-    gh pr create --title "$feature_name - RESTART" --body "https://justsimplesolutions.atlassian.net/browse/"$feature_name --base=$branch_PR --head=$branch --label "NFR"
+    if [[ $JGIT_NO_OPEN == true ]]; then
+        echo "Skipping pull request creation (--no-open)."
+    else
+        echo "Create pull request"
+        gh pr create --title "$feature_name - RESTART" --body "https://justsimplesolutions.atlassian.net/browse/$feature_name" --base=$branch_PR --head=$branch --label "NFR"
+    fi
 }

--- a/functions.sh
+++ b/functions.sh
@@ -12,10 +12,6 @@ if [[ -z "${JGIT_AUTO_YES+x}" ]]; then
   JGIT_AUTO_YES=false
 fi
 
-if [[ -z "${JGIT_DRY_RUN+x}" ]]; then
-  JGIT_DRY_RUN=false
-fi
-
 if [[ -z "${JGIT_NO_OPEN+x}" ]]; then
   JGIT_NO_OPEN=false
 fi
@@ -29,50 +25,6 @@ declare -a JGIT_FROM_SOURCES
 ###############################################
 #            Helpers génériques
 ###############################################
-
-# Wrapper git permettant de simuler les commandes en mode dry-run.
-__jgit_git_mutating() {
-  local subcmd="$1"
-  case "$subcmd" in
-    add|branch|checkout|cherry-pick|commit|fetch|merge|pull|push|rebase|reset|stash|switch|tag)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
-git() {
-  if [[ $# -eq 0 ]]; then
-    command git
-    return $?
-  fi
-
-  local subcmd="$1"
-  shift || true
-
-  if [[ "$subcmd" == "--version" ]]; then
-    command git --version "$@"
-    return $?
-  fi
-
-  if [[ $JGIT_DRY_RUN == true ]] && __jgit_git_mutating "$subcmd"; then
-    echo "[dry-run] git $subcmd $*"
-    return 0
-  fi
-
-  command git "$subcmd" "$@"
-}
-
-gh() {
-  if [[ $JGIT_DRY_RUN == true ]]; then
-    echo "[dry-run] gh $*"
-    return 0
-  fi
-
-  command gh "$@"
-}
 
 confirm_action() {
   local prompt="$1"
@@ -112,19 +64,11 @@ exit_safe() {
 
     if [[ $exit_code -ne 0 ]]; then
         echo "checkout on $current_branch"
-        if [[ $JGIT_DRY_RUN == true ]]; then
-            echo "[dry-run] would restore working branch $current_branch"
-        else
-            checkout_if_exists "$current_branch"
-        fi
+        checkout_if_exists "$current_branch"
     fi
 
     if [[ $stash == true ]]; then
-        if [[ $JGIT_DRY_RUN == true ]]; then
-            echo "[dry-run] git stash pop"
-        else
-            git stash pop
-        fi
+        git stash pop
     fi
 
     if [[ $exit_code -ne 0 ]]; then
@@ -147,13 +91,8 @@ verify_stash() {
         if ! confirm_action "Do you want to stash and unstash changes at the end of process ?" "y"; then
             exit_safe 1
         fi
-        if [[ $JGIT_DRY_RUN == true ]]; then
-            echo "[dry-run] git stash save \"[jGIT]\""
-            stash=false
-        else
-            git stash save "[jGIT]"
-            stash=true
-        fi
+        git stash save "[jGIT]"
+        stash=true
     fi
 }
 

--- a/functions.sh
+++ b/functions.sh
@@ -49,13 +49,8 @@ verify_stash() {
 #
 # Si la branche de référence n'existe pas une erreur est lancée.
 get_reference_branch() {
-    local feature_type=$1
+    local feature_type=${1:-feature}
     local fallback_branches=("develop2" "master2" "develop" "master" "main")
-
-    if [ -z "$feature_type" ]; then
-        echo "Erreur: Aucun feature_type fourni."
-        exit_safe 1
-    fi
 
     # Vérifier la branche en fonction du type de feature
     if [ "$feature_type" == "hotfix" ] && git rev-parse --verify "$branch_prod" >/dev/null 2>&1; then

--- a/functions.sh
+++ b/functions.sh
@@ -6,20 +6,132 @@
 ###############################################
 ###############################################
 
+# Valeurs par défaut pour les options globales lorsque le script est
+# exécuté directement (les variables sont normalement définies dans jgit.sh).
+if [[ -z "${JGIT_AUTO_YES+x}" ]]; then
+  JGIT_AUTO_YES=false
+fi
+
+if [[ -z "${JGIT_DRY_RUN+x}" ]]; then
+  JGIT_DRY_RUN=false
+fi
+
+if [[ -z "${JGIT_NO_OPEN+x}" ]]; then
+  JGIT_NO_OPEN=false
+fi
+
+if [[ -z "${JGIT_BASED_ON_OVERRIDE+x}" ]]; then
+  JGIT_BASED_ON_OVERRIDE=""
+fi
+
+declare -a JGIT_FROM_SOURCES
+
+###############################################
+#            Helpers génériques
+###############################################
+
+# Wrapper git permettant de simuler les commandes en mode dry-run.
+__jgit_git_mutating() {
+  local subcmd="$1"
+  case "$subcmd" in
+    add|branch|checkout|cherry-pick|commit|fetch|merge|pull|push|rebase|reset|stash|switch|tag)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+git() {
+  if [[ $# -eq 0 ]]; then
+    command git
+    return $?
+  fi
+
+  local subcmd="$1"
+  shift || true
+
+  if [[ "$subcmd" == "--version" ]]; then
+    command git --version "$@"
+    return $?
+  fi
+
+  if [[ $JGIT_DRY_RUN == true ]] && __jgit_git_mutating "$subcmd"; then
+    echo "[dry-run] git $subcmd $*"
+    return 0
+  fi
+
+  command git "$subcmd" "$@"
+}
+
+gh() {
+  if [[ $JGIT_DRY_RUN == true ]]; then
+    echo "[dry-run] gh $*"
+    return 0
+  fi
+
+  command gh "$@"
+}
+
+confirm_action() {
+  local prompt="$1"
+  local default_response=${2:-"y"}
+
+  if [[ $JGIT_AUTO_YES == true ]]; then
+    echo "[auto-confirm] $prompt"
+    return 0
+  fi
+
+  local suffix="(y/n)"
+  local expected="y"
+
+  if [[ "$default_response" == "n" ]]; then
+    suffix="(n/y)"
+    expected="n"
+  fi
+
+  local user_input
+  read -p "$prompt $suffix " user_input
+  echo
+
+  if [[ -z "$user_input" ]]; then
+    user_input="$default_response"
+  fi
+
+  if [[ "$user_input" == "$expected" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 # fonction à appeler systématiquement permet de remettre les données stashée au départ en cas d'arrêt du script.
 exit_safe() {
-    echo "checkout on $current_branch"
-    checkout_if_exists $current_branch
+    local exit_code=${1:-0}
 
-    if $stash; then
-        git stash pop
+    if [[ $exit_code -ne 0 ]]; then
+        echo "checkout on $current_branch"
+        if [[ $JGIT_DRY_RUN == true ]]; then
+            echo "[dry-run] would restore working branch $current_branch"
+        else
+            checkout_if_exists "$current_branch"
+        fi
     fi
 
-    if [[ $1 != 0 ]]; then
+    if [[ $stash == true ]]; then
+        if [[ $JGIT_DRY_RUN == true ]]; then
+            echo "[dry-run] git stash pop"
+        else
+            git stash pop
+        fi
+    fi
+
+    if [[ $exit_code -ne 0 ]]; then
         echo "/!\ Script finished in error! Be careful about your branch management on local."
     fi
 
-    exit $1
+    exit $exit_code
 }
 
 ###############################################
@@ -32,13 +144,16 @@ exit_safe() {
 verify_stash() {
     if [[ $(git status --porcelain) ]]; then
         echo "You have uncommited modifications."
-        read -p "Do you want to stash and unstash changes at the end of process ? [y/n] " yn
-        echo
-        if [[ ! $yn =~ ^[Yy]$ ]]; then
+        if ! confirm_action "Do you want to stash and unstash changes at the end of process ?" "y"; then
             exit_safe 1
         fi
-        git stash save "[jGIT]"
-        stash=true;
+        if [[ $JGIT_DRY_RUN == true ]]; then
+            echo "[dry-run] git stash save \"[jGIT]\""
+            stash=false
+        else
+            git stash save "[jGIT]"
+            stash=true
+        fi
     fi
 }
 
@@ -123,8 +238,7 @@ cherry_pick() {
         "$(tput setaf 1)" "$(tput sgr0)"
     
         # Demander confirmation à l'utilisateur
-        read -p "Avez vous résolu et commité la résolution de conflit ? (y/n) " user_input
-        if [[ "$user_input" != "y" ]]; then
+        if ! confirm_action "Avez vous résolu et commité la résolution de conflit ?" "y"; then
             echo "Opération annulée."
             git cherry-pick --abort
             exit_safe 1
@@ -213,12 +327,12 @@ checkout_or_create_branch() {
   if git show-ref --verify --quiet "refs/heads/$branch"; then
       # La branche existe en local
       git checkout "$branch" --quiet
-      git pull --ff-only origin "$branch" --quiet
+      git pull --ff-only "$j2s_remote" "$branch" --quiet
 
-  elif git ls-remote --exit-code --heads origin "$branch" > /dev/null; then
-      # La branche existe sur origin mais pas en local
-      git fetch origin --quiet
-      git checkout -b "$branch" "origin/$branch" --quiet
+  elif git ls-remote --exit-code --heads "$j2s_remote" "$branch" > /dev/null; then
+      # La branche existe sur le remote mais pas en local
+      git fetch "$j2s_remote" "$branch:$branch" --quiet
+      git checkout "$branch" --quiet
   else
     echo "Bascule vers '$branch' (Création depuis la branche courante)"
     git checkout -b "$branch"
@@ -236,12 +350,12 @@ checkout_if_exists() {
   if git show-ref --verify --quiet "refs/heads/$branch"; then
       # La branche existe en local
       git checkout "$branch" --quiet
-      git pull --ff-only origin "$branch" --quiet
+      git pull --ff-only "$j2s_remote" "$branch" --quiet
 
-  elif git ls-remote --exit-code --heads origin "$branch" > /dev/null; then
-      # La branche existe sur origin mais pas en local
-      git fetch origin --quiet
-      git checkout -b "$branch" "origin/$branch" --quiet
+  elif git ls-remote --exit-code --heads "$j2s_remote" "$branch" > /dev/null; then
+      # La branche existe sur le remote mais pas en local
+      git fetch "$j2s_remote" "$branch:$branch" --quiet
+      git checkout "$branch" --quiet
   else
     echo "La branche n'existe pas"
     exit_safe 1

--- a/jgit.sh
+++ b/jgit.sh
@@ -1,6 +1,7 @@
 source "$(dirname "$0")/feature.sh"
 source "$(dirname "$0")/release.sh"
 source "$(dirname "$0")/rebase.sh"
+source "$(dirname "$0")/demo.sh"
 
 ####################################
 #
@@ -55,6 +56,18 @@ help() {
     printf "    → Ferme la release en cours : fusion de la branche release,\n"
     printf "      création du tag et publication sur GitHub.\n\n"
 
+    printf "  jgit \033[1;32mdemo\033[0m start \033[1;36m[demo_name]\033[0m \033[38;5;214m[OPTIONAL]\033[0m --based-on \033[1;36m<branch_name>\033[0m\n"
+    printf "    → Crée ou reprend une branche de démo (prefixée demo_).\n\n"
+
+    printf "  jgit \033[1;32mdemo\033[0m merge \033[1;36m<branch_name>\033[0m\n"
+    printf "    → Injecte la branche indiquée dans la démo courante.\n\n"
+
+    printf "  jgit \033[1;32mdemo\033[0m list\n"
+    printf "    → Liste les features mergées dans la démo.\n\n"
+
+    printf "  jgit \033[1;32mdemo\033[0m remove\n"
+    printf "    → Supprime la branche de démo courante en local et sur le remote.\n\n"
+
     printf "  jgit \033[1;32mclean\033[0m\n"
     printf "    → Nettoie les branches locales temporaires comme les branches de rebase et __PR__.\n\n"
 
@@ -72,6 +85,7 @@ help() {
 JGIT_TYPE=$1
 JGIT_ACTION=$2
 JGIT_NAME=$3
+JGIT_TARGET=$4
 JGIT_BASED_ON=""  # Valeur par défaut
 
 
@@ -146,6 +160,35 @@ elif [[ $JGIT_TYPE == "release" ]]; then
         fi
         branch_PR=$prefix_PR$JGIT_NAME
         release_merge;
+    else
+        echo "argument $JGIT_ACTION not supported"
+        exit_safe 1
+    fi
+elif [[ $JGIT_TYPE == "demo" ]]; then
+    if [[ -z $JGIT_ACTION ]]; then
+        help
+    fi
+
+    if [[ $JGIT_ACTION == "start" ]]; then
+        verify_stash
+        demo_start "$JGIT_NAME" "$JGIT_BASED_ON"
+    elif [[ $JGIT_ACTION == "merge" ]]; then
+        if [[ $JGIT_NAME == "feature" ]]; then
+            if [[ -z $JGIT_TARGET ]]; then
+                echo "Please set a feature name as fourth argument"
+                exit_safe 1
+            fi
+            verify_stash
+            demo_merge_feature "$JGIT_TARGET"
+        else
+            echo "argument $JGIT_NAME not supported"
+            exit_safe 1
+        fi
+    elif [[ $JGIT_ACTION == "list" ]]; then
+        demo_list
+    elif [[ $JGIT_ACTION == "remove" ]]; then
+        verify_stash
+        demo_remove
     else
         echo "argument $JGIT_ACTION not supported"
         exit_safe 1

--- a/jgit.sh
+++ b/jgit.sh
@@ -35,7 +35,6 @@ prefix_init_commit="$prefix_commit INIT"
 suffix_init_commit="[empty_commit]"
 
 JGIT_AUTO_YES=false
-JGIT_DRY_RUN=false
 JGIT_NO_OPEN=false
 JGIT_BASED_ON_OVERRIDE=""
 JGIT_INTO_TARGET=""
@@ -58,7 +57,6 @@ help() {
     printf "  --from <branch>       Source d'un merge (répétable).\n"
     printf "  --into <branch>       Destination explicite d'un merge.\n"
     printf "  --yes                 Valide automatiquement les confirmations.\n"
-    printf "  --dry-run             Affiche les actions sans les exécuter.\n"
     printf "  --no-open             N'ouvre pas automatiquement la PR.\n"
     printf "  -h | --help           Affiche cette aide.\n\n"
 
@@ -139,10 +137,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --yes|-y)
             JGIT_AUTO_YES=true
-            shift
-            ;;
-        --dry-run)
-            JGIT_DRY_RUN=true
             shift
             ;;
         --no-open)

--- a/jgit.sh
+++ b/jgit.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source "$(dirname "$0")/feature.sh"
 source "$(dirname "$0")/release.sh"
 source "$(dirname "$0")/rebase.sh"
@@ -16,7 +18,8 @@ branch_preprod="develop"
 
 FILE=.jgit/conf_local.sh
 if test -f "$FILE"; then
-    source $FILE
+    # shellcheck disable=SC1090
+    source "$FILE"
 fi
 
 ####################################
@@ -31,7 +34,14 @@ prefix_commit="[jgit]"
 prefix_init_commit="$prefix_commit INIT"
 suffix_init_commit="[empty_commit]"
 
-stash=false;
+JGIT_AUTO_YES=false
+JGIT_DRY_RUN=false
+JGIT_NO_OPEN=false
+JGIT_BASED_ON_OVERRIDE=""
+JGIT_INTO_TARGET=""
+declare -a JGIT_FROM_SOURCES=()
+
+stash=false
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 ################################################################################
@@ -39,73 +49,155 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 ################################################################################
 help() {
     printf "\n\033[1;34mUsage:\033[0m\n"
-    printf "  jgit \033[1;32m[feature|hotfix]\033[0m start \033[1;36m<feature_name>\033[0m \033[38;5;214m[OPTIONAL]\033[0m --based-on \033[1;36m<branch_name>\033[0m\n"
-    printf "    → Crée une nouvelle feature ou hotfix ou permet de s'y positionner.\n"
-    printf "    → --based-on permet de choisir la branche sur laquelle se baser.\n\n"
+    printf "  jgit \033[1;32m<scope>\033[0m \033[1;36m<action>\033[0m \033[38;5;214m[<target>]\033[0m \033[38;5;214m[options…]\033[0m\n\n"
 
-    printf "  jgit \033[1;32m[feature|hotfix]\033[0m rebase \033[1;36m<feature_name>\033[0m \033[38;5;214m[OPTIONAL]\033[0m --based-on \033[1;36m<branch_name>\033[0m\n"
-    printf "    → Rebase la feature ou le hotfix sur la branche principale.\n"
-    printf "      En cas de conflits, suivez les commandes git avant de relancer ce script.\n\n"
-    printf "    → --based-on permet de choisir la branche sur laquelle se baser.\n"
+    printf "\033[1;34mScopes:\033[0m feature | hotfix | release | demo | util\n\n"
 
-    printf "  jgit \033[1;32mrelease\033[0m merge \033[1;36m<branch_name>\033[0m\n"
-    printf "    → Fusionne une branche dans la release en cours.\n"
-    printf "    → La release est créée à la volée au besoin.\n\n"
+    printf "\033[1;34mOptions communes:\033[0m\n"
+    printf "  --based-on <branch>   Branche de référence pour les créations / rebase.\n"
+    printf "  --from <branch>       Source d'un merge (répétable).\n"
+    printf "  --into <branch>       Destination explicite d'un merge.\n"
+    printf "  --yes                 Valide automatiquement les confirmations.\n"
+    printf "  --dry-run             Affiche les actions sans les exécuter.\n"
+    printf "  --no-open             N'ouvre pas automatiquement la PR.\n"
+    printf "  -h | --help           Affiche cette aide.\n\n"
 
-    printf "  jgit \033[1;32mrelease\033[0m finish\n"
-    printf "    → Ferme la release en cours : fusion de la branche release,\n"
-    printf "      création du tag et publication sur GitHub.\n\n"
+    printf "\033[1;34mFeature & Hotfix:\033[0m\n"
+    printf "  jgit feature start <ticket> [--based-on <branch>] [--no-open]\n"
+    printf "  jgit feature restart <ticket>\n"
+    printf "  jgit feature rebase <ticket> [--based-on <branch>]\n"
+    printf "  (idem avec hotfix)\n\n"
 
-    printf "  jgit \033[1;32mdemo\033[0m start \033[1;36m[demo_name]\033[0m \033[38;5;214m[OPTIONAL]\033[0m --based-on \033[1;36m<branch_name>\033[0m\n"
-    printf "    → Crée ou reprend une branche de démo (prefixée demo_).\n\n"
+    printf "\033[1;34mRelease:\033[0m\n"
+    printf "  jgit release start [<x.y.z>]\n"
+    printf "  jgit release merge [<x.y.z>] --from <branch> [--into <branch>]\n"
+    printf "  jgit release finish\n\n"
 
-    printf "  jgit \033[1;32mdemo\033[0m merge \033[1;36m<branch_name>\033[0m\n"
-    printf "    → Injecte la branche indiquée dans la démo courante.\n\n"
+    printf "\033[1;34mDemo:\033[0m\n"
+    printf "  jgit demo start [<demo_name>] [--based-on <branch>]\n"
+    printf "  jgit demo merge [--from feature/<ticket>]... [--into <branch>]\n"
+    printf "  jgit demo list\n"
+    printf "  jgit demo remove [--yes]\n\n"
 
-    printf "  jgit \033[1;32mdemo\033[0m list\n"
-    printf "    → Liste les features mergées dans la démo.\n\n"
-
-    printf "  jgit \033[1;32mdemo\033[0m remove\n"
-    printf "    → Supprime la branche de démo courante en local et sur le remote.\n\n"
-
-    printf "  jgit \033[1;32mclean\033[0m\n"
-    printf "    → Nettoie les branches locales temporaires comme les branches de rebase et __PR__.\n\n"
-
-    printf "\033[1;34mOptions:\033[0m\n"
-    printf "  -h    Affiche cette aide.\n\n"
+    printf "\033[1;34mUtility:\033[0m\n"
+    printf "  jgit util clean\n\n"
 }
 
+require_argument() {
+    local option="$1"
+    local value="$2"
+    if [[ -z "$value" || "$value" == -* ]]; then
+        printf "\033[1;31mErreur : l'option %s requiert une valeur.\033[0m\n" "$option" >&2
+        exit_safe 1
+    fi
+}
+
+ensure_remote() {
+    local remotes
+    remotes=$(git remote -v)
+
+    if [[ $remotes != *"$j2s_remote"* ]]; then
+        echo "Please configure J2S remote as $j2s_remote"
+        exit_safe 1
+    fi
+}
 
 ####################################
 #
 #      Manage parameters
 #
 ####################################
-# Définition des variables
-JGIT_TYPE=$1
-JGIT_ACTION=$2
-JGIT_NAME=$3
-JGIT_TARGET=$4
-JGIT_BASED_ON=""  # Valeur par défaut
 
+if [[ $# -eq 0 ]]; then
+    help
+    exit_safe 0
+fi
 
-# Parcourir tous les arguments
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+    help
+    exit_safe 0
+fi
+
+positional=()
+
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --based-on)
-      if [[ -n "$2" && "$2" != -* ]]; then
-        JGIT_BASED_ON="$2"  # Récupérer la valeur suivante
-        shift 2         # Passer à l'argument suivant
-      else
-        echo "Erreur : L'option --based-on nécessite un argument." >&2
-        exit_safe 1
-      fi
-      ;;
-    *)
-      shift
-      ;;
-  esac
+    case "$1" in
+        --based-on)
+            require_argument "--based-on" "$2"
+            JGIT_BASED_ON_OVERRIDE="$2"
+            shift 2
+            ;;
+        --from)
+            require_argument "--from" "$2"
+            JGIT_FROM_SOURCES+=("$2")
+            shift 2
+            ;;
+        --into)
+            require_argument "--into" "$2"
+            JGIT_INTO_TARGET="$2"
+            shift 2
+            ;;
+        --yes|-y)
+            JGIT_AUTO_YES=true
+            shift
+            ;;
+        --dry-run)
+            JGIT_DRY_RUN=true
+            shift
+            ;;
+        --no-open)
+            JGIT_NO_OPEN=true
+            shift
+            ;;
+        --help)
+            help
+            exit_safe 0
+            ;;
+        --)
+            shift
+            while [[ $# -gt 0 ]]; do
+                positional+=("$1")
+                shift
+            done
+            ;;
+        -* )
+            printf "\033[1;31mOption inconnue : %s\033[0m\n" "$1" >&2
+            exit_safe 1
+            ;;
+        *)
+            positional+=("$1")
+            shift
+            ;;
+    esac
 done
+
+JGIT_TYPE="${positional[0]}"
+JGIT_ACTION="${positional[1]}"
+JGIT_TARGET="${positional[2]}"
+extra_positionals=()
+if [[ ${#positional[@]} -gt 3 ]]; then
+    extra_positionals=("${positional[@]:3}")
+fi
+
+if [[ -z "$JGIT_TYPE" ]]; then
+    help
+    exit_safe 0
+fi
+
+if [[ "$JGIT_TYPE" == "help" ]]; then
+    help
+    exit_safe 0
+fi
+
+if [[ "$JGIT_TYPE" == "-h" ]]; then
+    help
+    exit_safe 0
+fi
+
+if [[ ${#extra_positionals[@]} -gt 0 ]]; then
+    printf "\033[1;31mArguments supplémentaires non reconnus : %s\033[0m\n" "${extra_positionals[*]}" >&2
+    exit_safe 1
+fi
 
 ####################################
 #
@@ -113,93 +205,116 @@ done
 #
 ####################################
 
-# GLOBAL VERIFICATIONS
-remotes=$( git remote -v )
+ensure_remote
 
-if [[ $remotes != *$j2s_remote* ]]; then
-  echo "Please configure J2S remote as "$j2s_remote
-  exit_safe 1
-fi
-
-# Manage syntax
-if [[ $JGIT_TYPE == "feature" ]] || [[ $JGIT_TYPE == "hotfix" ]]; then
-    if [[ -z $JGIT_NAME ]]; then
-        echo "Please set a $JGIT_TYPE name as third argument"
-        exit_safe 1;
-    fi
-    
-    if [[ -z $JGIT_ACTION ]]; then
-        help
-    fi
-    if [[ $JGIT_ACTION == "start" ]]; then
-        verify_stash
-        feature_start $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON;
-    elif [[ $JGIT_ACTION == "restart" ]]; then
-        verify_stash
-        feature_restart $JGIT_TYPE $JGIT_NAME
-    elif [[ $JGIT_ACTION == "rebase" ]]; then
-        verify_stash
-        feature_rebase $JGIT_TYPE $JGIT_NAME $JGIT_BASED_ON
-    else
-        echo "argument $JGIT_ACTION note supported"
-        exit_safe 1
-    fi
-elif [[ $JGIT_TYPE == "release" ]]; then
-    if [[ -z $JGIT_ACTION ]]; then
-        help
-    fi
-    verify_stash
-    if [[ $JGIT_ACTION == "start" ]]; then 
-        release_start;
-    elif [[ $JGIT_ACTION == "finish" ]]; then 
-        release_finish;
-    elif [[ $JGIT_ACTION == "merge" ]]; then 
-        if [[ -z $JGIT_NAME ]]; then
-            echo "Please set a branch name as third argument"
-            exit_safe 1;
-        fi
-        branch_PR=$prefix_PR$JGIT_NAME
-        release_merge;
-    else
-        echo "argument $JGIT_ACTION not supported"
-        exit_safe 1
-    fi
-elif [[ $JGIT_TYPE == "demo" ]]; then
-    if [[ -z $JGIT_ACTION ]]; then
-        help
-    fi
-
-    if [[ $JGIT_ACTION == "start" ]]; then
-        verify_stash
-        demo_start "$JGIT_NAME" "$JGIT_BASED_ON"
-    elif [[ $JGIT_ACTION == "merge" ]]; then
-        if [[ $JGIT_NAME == "feature" ]]; then
-            if [[ -z $JGIT_TARGET ]]; then
-                echo "Please set a feature name as fourth argument"
-                exit_safe 1
-            fi
-            verify_stash
-            demo_merge_feature "$JGIT_TARGET"
-        else
-            echo "argument $JGIT_NAME not supported"
+case "$JGIT_TYPE" in
+    feature|hotfix)
+        if [[ -z "$JGIT_ACTION" ]]; then
+            help
             exit_safe 1
         fi
-    elif [[ $JGIT_ACTION == "list" ]]; then
-        demo_list
-    elif [[ $JGIT_ACTION == "remove" ]]; then
-        verify_stash
-        demo_remove
-    else
-        echo "argument $JGIT_ACTION not supported"
+        case "$JGIT_ACTION" in
+            start)
+                if [[ -z "$JGIT_TARGET" ]]; then
+                    echo "Please set a $JGIT_TYPE identifier." >&2
+                    exit_safe 1
+                fi
+                verify_stash
+                feature_start "$JGIT_TYPE" "$JGIT_TARGET" "$JGIT_BASED_ON_OVERRIDE"
+                ;;
+            restart)
+                if [[ -z "$JGIT_TARGET" ]]; then
+                    echo "Please set a $JGIT_TYPE identifier." >&2
+                    exit_safe 1
+                fi
+                verify_stash
+                feature_restart "$JGIT_TYPE" "$JGIT_TARGET"
+                ;;
+            rebase)
+                if [[ -z "$JGIT_TARGET" ]]; then
+                    echo "Please set a $JGIT_TYPE identifier." >&2
+                    exit_safe 1
+                fi
+                verify_stash
+                feature_rebase "$JGIT_TYPE" "$JGIT_TARGET" "$JGIT_BASED_ON_OVERRIDE"
+                ;;
+            *)
+                printf "\033[1;31mAction '%s' non supportée pour %s.\033[0m\n" "$JGIT_ACTION" "$JGIT_TYPE" >&2
+                exit_safe 1
+                ;;
+        esac
+        ;;
+    release)
+        if [[ -z "$JGIT_ACTION" ]]; then
+            help
+            exit_safe 1
+        fi
+        case "$JGIT_ACTION" in
+            start)
+                verify_stash
+                release_start "$JGIT_TARGET"
+                ;;
+            merge)
+                if [[ ${#JGIT_FROM_SOURCES[@]} -eq 0 ]]; then
+                    echo "Veuillez spécifier au moins une source avec --from." >&2
+                    exit_safe 1
+                fi
+                verify_stash
+                release_merge "$JGIT_TARGET" "$JGIT_INTO_TARGET" "${JGIT_FROM_SOURCES[@]}"
+                ;;
+            finish)
+                verify_stash
+                release_finish "$JGIT_INTO_TARGET"
+                ;;
+            *)
+                printf "\033[1;31mAction '%s' non supportée pour release.\033[0m\n" "$JGIT_ACTION" >&2
+                exit_safe 1
+                ;;
+        esac
+        ;;
+    demo)
+        if [[ -z "$JGIT_ACTION" ]]; then
+            help
+            exit_safe 1
+        fi
+        case "$JGIT_ACTION" in
+            start)
+                verify_stash
+                demo_start "$JGIT_TARGET" "$JGIT_BASED_ON_OVERRIDE"
+                ;;
+            merge)
+                if [[ ${#JGIT_FROM_SOURCES[@]} -eq 0 ]]; then
+                    echo "Veuillez préciser au moins une source avec --from." >&2
+                    exit_safe 1
+                fi
+                verify_stash
+                demo_merge "$JGIT_INTO_TARGET" "${JGIT_FROM_SOURCES[@]}"
+                ;;
+            list)
+                demo_list
+                ;;
+            remove)
+                verify_stash
+                demo_remove
+                ;;
+            *)
+                printf "\033[1;31mAction '%s' non supportée pour demo.\033[0m\n" "$JGIT_ACTION" >&2
+                exit_safe 1
+                ;;
+        esac
+        ;;
+    util)
+        if [[ "$JGIT_ACTION" == "clean" ]]; then
+            clean_branches
+        else
+            printf "\033[1;31mAction '%s' non supportée pour util.\033[0m\n" "$JGIT_ACTION" >&2
+            exit_safe 1
+        fi
+        ;;
+    *)
+        printf "\033[1;31mScope '%s' non supporté.\033[0m\n" "$JGIT_TYPE" >&2
         exit_safe 1
-    fi
-elif [[ $JGIT_TYPE == "help" ]] || [[ $JGIT_TYPE == "-h" ]]; then
-    help
-    exit_safe 0;
-elif [[ $JGIT_TYPE == "clean" ]]; then
-    clean_branches
-else
-    echo "argument $JGIT_TYPE not supported"
-    exit_safe 1
-fi
+        ;;
+ esac
+
 exit_safe 0

--- a/rebase.sh
+++ b/rebase.sh
@@ -134,8 +134,7 @@ feature_rebase() {
     "$(tput setaf 2)" "$(tput setaf 1)" "$reference_branch" "$(tput sgr0)"
     
     # Demander confirmation à l'utilisateur
-    read -p "Souhaitez-vous continuer ? (y/n) " user_input
-    if [[ "$user_input" != "y" ]]; then
+    if ! confirm_action "Souhaitez-vous continuer ?" "y"; then
         echo "Opération annulée."
         exit_safe 1
     fi
@@ -167,8 +166,7 @@ feature_rebase() {
     git checkout $branch
     git_history_with_merges "$branch" "$reference_branch"
 
-    read -p "Confirmez-vous que le rebase s'est bien passé, les branches vont être push --force ? (y/n) " user_input
-    if [[ "$user_input" != "y" ]]; then
+    if ! confirm_action "Confirmez-vous que le rebase s'est bien passé, les branches vont être push --force ?" "y"; then
         echo "les branches locales ne sont plus correctes ($branch et $branch_PR), elles vont être supprimées en local."
         git checkout $reference_branch --quiet
         git branch -D $branch

--- a/release.sh
+++ b/release.sh
@@ -5,147 +5,269 @@ source "$(dirname "$0")/functions.sh"
 #            RELEASE
 ####################################
 
-release_start() {
-    if [[ $(git status --porcelain) ]]; then
-        echo "/!\ Local changes, cannot start release"
-        exit_safe 1;
+normalize_release_branch_name() {
+    local identifier="$1"
+    if [[ -z "$identifier" ]]; then
+        echo ""
+        return 0
     fi
-
-    git checkout $branch_prod
-    git fetch $j2s_remote
-    current_tag=$(git tag -l --sort=-creatordate | head -n 1)
-    echo "Current tag: ${current_tag}"
-    major=0
-    feature=0
-    minor=0
-
-    regex="([0-9]+).([0-9]+).([0-9]+)"
-    if [[ $current_tag =~ $regex ]]; then
-        major="${BASH_REMATCH[1]}"
-        feature="${BASH_REMATCH[2]}"
-        minor="${BASH_REMATCH[3]}"
+    if [[ "$identifier" == release/* ]]; then
+        echo "$identifier"
     else
-        echo "A tag must already exists (x.x.x format)"
+        echo "release/$identifier"
+    fi
+}
 
+checkout_release_branch() {
+    local branch="$1"
+
+    if [[ -z "$branch" ]]; then
+        printf "\033[1;31mErreur : aucune branche de release fournie.\033[0m\n"
         exit_safe 1
     fi
-    feature=$(echo $feature + 1 | bc)
-    future_tag="${major}.${feature}.${minor}"
 
-    branch=release/${future_tag};
-    existed_in_local=$(git branch --list ${branch})
-    existed_in_remote=$(git ls-remote --heads $j2s_remote ${branch})
+    if git show-ref --verify --quiet "refs/heads/$branch"; then
+        git checkout "$branch" --quiet
+        git pull "$j2s_remote" "$branch" --quiet
+    elif git ls-remote --exit-code --heads "$j2s_remote" "$branch" >/dev/null 2>&1; then
+        git fetch "$j2s_remote" "$branch:$branch" --quiet
+        git checkout "$branch" --quiet
+    else
+        printf "\033[1;31mLa branche %s n'existe pas (ni en local ni sur %s).\033[0m\n" "$branch" "$j2s_remote"
+        exit_safe 1
+    fi
+
+    current_branch="$branch"
+}
+
+resolve_release_source_branch() {
+    local source="$1"
+    if [[ -z "$source" ]]; then
+        echo ""
+        return 0
+    fi
+
+    if [[ "$source" == __PR__* ]]; then
+        echo "$source"
+    else
+        echo "$prefix_PR$source"
+    fi
+}
+
+release_start() {
+    local requested_version="$1"
+    local future_tag=""
+    local prod_branch
+
+    prod_branch=$(get_reference_branch "hotfix")
+
+    if [[ $(git status --porcelain) ]]; then
+        echo "/!\\ Local changes, cannot start release"
+        exit_safe 1
+    fi
+
+    git checkout "$prod_branch"
+    git fetch "$j2s_remote"
+
+    if [[ -n "$requested_version" ]]; then
+        future_tag="$requested_version"
+    else
+        local current_tag
+        current_tag=$(git tag -l --sort=-creatordate | head -n 1)
+        echo "Current tag: ${current_tag}"
+
+        local major=0
+        local feature=0
+        local minor=0
+        local regex='([0-9]+)\.([0-9]+)\.([0-9]+)'
+
+        if [[ $current_tag =~ $regex ]]; then
+            major="${BASH_REMATCH[1]}"
+            feature="${BASH_REMATCH[2]}"
+            minor="${BASH_REMATCH[3]}"
+        else
+            echo "A tag must already exists (x.x.x format)"
+            exit_safe 1
+        fi
+
+        feature=$((feature + 1))
+        future_tag="${major}.${feature}.${minor}"
+    fi
+
+    local branch
+    branch=$(normalize_release_branch_name "$future_tag")
+    local existed_in_local
+    existed_in_local=$(git branch --list "$branch")
+    local existed_in_remote
+    existed_in_remote=$(git ls-remote --heads "$j2s_remote" "$branch")
 
     echo "Searching a branch naming: ${branch}"
 
-    if [[ ! -z ${existed_in_remote} ]]; then
-        if [[ ! -z ${existed_in_local} ]]; then
+    if [[ -n ${existed_in_remote} ]]; then
+        if [[ -n ${existed_in_local} ]]; then
             echo "Release ${branch} local branch exists, deletion..."
-            git branch -D ${branch}
+            git branch -D "$branch"
         fi
         echo "Remote branch exists, use it..."
-        git checkout --track $j2s_remote/${branch}
-    
-        return 1;
+        git checkout --track "$j2s_remote/$branch"
+        git pull "$j2s_remote" "$branch" --quiet
+    else
+        echo "Release does not exists, create it..."
+        git reset --hard "$j2s_remote/$prod_branch"
+        git checkout -b "$branch"
+        git commit --allow-empty -m "$prefix_init_commit release ${branch}. $suffix_init_commit"
+        git push "$j2s_remote" "$branch"
     fi
 
-    echo "Release does not exists, create it..."
-    git reset --hard $j2s_remote/$branch_prod
-    git checkout -b ${branch}
-    git commit --allow-empty -m "$prefix_init_commit release ${branch}. $suffix_init_commit"
-    git push $j2s_remote ${branch}
+    current_branch="$branch"
+    echo "$branch"
+}
+
+release_merge_single() {
+    local release_branch="$1"
+    local source_branch="$2"
+
+    local resolved_branch
+    resolved_branch=$(resolve_release_source_branch "$source_branch")
+    if [[ -z "$resolved_branch" ]]; then
+        printf "\033[1;31mAucune branche source fournie.\033[0m\n"
+        exit_safe 1
+    fi
+
+    local existed_in_local
+    existed_in_local=$(git branch --list "$resolved_branch")
+    local existed_in_remote
+    existed_in_remote=$(git ls-remote --heads "$j2s_remote" "$resolved_branch")
+    local merge_source=""
+
+    if [[ -n "$existed_in_local" ]]; then
+        echo "Feature branch exists on local machine, use it..."
+        merge_source="$resolved_branch"
+    elif [[ -n "$existed_in_remote" ]]; then
+        echo "Remote branch exists, use it..."
+        merge_source="$j2s_remote/$resolved_branch"
+    else
+        printf "\033[1;31m/!\\ Feature branch '%s' was not found!\033[0m\n" "$resolved_branch"
+        exit_safe 1
+    fi
+
+    local last_commit_subject
+    last_commit_subject=$(git log -1 --pretty=%s "$merge_source")
+    if [[ "$last_commit_subject" == "$prefix_init_commit $source_branch $suffix_init_commit" ]]; then
+        printf "\033[1;31m/!\\ La branche '%s' ne contient que le commit d'initialisation. Merci de valider et merger la PR avant d'intégrer dans la release.\033[0m\n" "$resolved_branch"
+        exit_safe 1
+    fi
+
+    git checkout "$release_branch" --quiet
+    git merge --no-ff "$merge_source" -m "$prefix_commit Release merge feature branch : $resolved_branch"
 }
 
 release_merge() {
-    release_start
-    branch=$branch_PR;
-    existed_in_local=$(git branch --list ${branch})
-    existed_in_remote=$(git ls-remote --heads $j2s_remote ${branch})
-    release_branch=$(git rev-parse --abbrev-ref HEAD)
-    existed=0
+    local requested_version="$1"
+    local explicit_into="$2"
+    shift 2 || true
+    local sources=("$@")
 
-    echo "Searching a branch naming: ${branch}"
-
-    if [[ ! -z ${existed_in_local} ]]; then
-        echo "Feature branch exists on local machine, use it..."
-        existed=1
-        git merge --no-ff ${branch} -m "$prefix_commit Merge feature branch : $branch"
-    fi
-
-    if [[ ! -z ${existed_in_remote} && existed=0 ]]; then
-        echo "Remote branch exists, use it..."
-        existed=1
-        git merge --no-ff $j2s_remote/${branch} -m "$prefix_commit Merge feature branch : $branch"
-    fi
-
-    if [[ $existed == 0 ]]; then
-        echo "/!\ Feature branch was not found!"
-
+    if [[ ${#sources[@]} -eq 0 ]]; then
+        echo "Aucune branche source à fusionner." >&2
         exit_safe 1
     fi
 
-   git push $j2s_remote ${release_branch}
+    local release_branch
+    if [[ -n "$explicit_into" ]]; then
+        release_branch=$(normalize_release_branch_name "$explicit_into")
+        checkout_release_branch "$release_branch"
+    else
+        release_start "$requested_version"
+        release_branch=$(git rev-parse --abbrev-ref HEAD)
+    fi
+
+    if [[ -z "$release_branch" ]]; then
+        release_branch=$(git rev-parse --abbrev-ref HEAD)
+    fi
+
+    for source in "${sources[@]}"; do
+        release_merge_single "$release_branch" "$source"
+    done
+
+    git push "$j2s_remote" "$release_branch"
 }
 
 release_finish() {
-    branch=$(git rev-parse --abbrev-ref HEAD)
-    regex_tag="([0-9]+).([0-9]+).([0-9]+)"
-    regex_branch="release/${regex_tag}"
+    local requested_target="$1"
+    local branch="$requested_target"
+    local prod_branch
+
+    prod_branch=$(get_reference_branch "hotfix")
+
+    if [[ -n "$requested_target" ]]; then
+        branch=$(normalize_release_branch_name "$requested_target")
+        checkout_release_branch "$branch"
+    else
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        local regex_branch='release/([0-9]+)\.([0-9]+)\.([0-9]+)'
+        if [[ ! $branch =~ $regex_branch ]]; then
+            release_start
+            branch=$(git rev-parse --abbrev-ref HEAD)
+        fi
+    fi
+
+    local regex_tag='([0-9]+)\.([0-9]+)\.([0-9]+)'
+    local regex_branch='release/'$regex_tag
 
     if [[ $branch =~ $regex_branch ]]; then
-    echo "Already in release branch"
-    future_feature="${BASH_REMATCH[2]}"
+        echo "Already in release branch"
+        local future_feature="${BASH_REMATCH[2]}"
 
-    current_tag=$(git tag -l --sort=-creatordate | head -n 1)
-    [[ $current_tag =~ $regex_tag ]] && current_feature="${BASH_REMATCH[2]}"
+        local current_tag
+        current_tag=$(git tag -l --sort=-creatordate | head -n 1)
+        local current_feature=0
+        if [[ $current_tag =~ $regex_tag ]]; then
+            current_feature="${BASH_REMATCH[2]}"
+        fi
 
-    if [[ $future_feature > $current_feature ]]; then
-        echo "Use current local release ${branch}"
+        if [[ $future_feature -le $current_feature ]]; then
+            echo "/!\\ Local release does not have the right tag, switching to new branch"
+            release_start
+            branch=$(git rev-parse --abbrev-ref HEAD)
+        fi
     else
-        echo "/!\ Local release does not have the right tag, switching to new branch"
+        echo "Switch to release branch"
         release_start
         branch=$(git rev-parse --abbrev-ref HEAD)
     fi
-    else
-    echo "Switch to release branch"
-    release_start
-    branch=$(git rev-parse --abbrev-ref HEAD)
-    fi
 
     echo "Release: ${branch}"
+    local last_commit_message
     last_commit_message=$(git log -1 --pretty=%B)
 
     if [[ $last_commit_message == "$prefix_init_commit release ${branch}. $suffix_init_commit" ]]; then
         echo "It seems that the release is empty..."
-
-        exit_safe 1;
-    fi
-
-    if [[ $branch =~ $regex_branch ]]; then
-        major="${BASH_REMATCH[1]}"
-        feature="${BASH_REMATCH[2]}"
-        minor="${BASH_REMATCH[3]}"
-    else
-        echo "Release branch seems to have a wrong format..."
-
         exit_safe 1
     fi
 
-    future_tag="${major}.${feature}.${minor}"
-    echo "Future tag: ${future_tag}"
-    git checkout $branch_prod
-    git fetch $j2s_remote
-    git reset --hard $j2s_remote/$branch_prod
-    echo "Merging release ${branch} in $branch_prod branch..."
-    git merge --no-ff ${branch} -m "Merge release branch : ${branch}"
-    echo "Create new tag ${future_tag}"
-    git tag ${future_tag}
-    git push $j2s_remote $branch_prod
-    echo "Delete local branch ${branch}"
-    git branch -D ${branch}
-    echo "Delete remote branch ${branch}"
-    git push -d $j2s_remote ${branch}
-    git push $j2s_remote tag ${future_tag}
-
-    gh release create ${future_tag} --generate-notes
+    if [[ $branch =~ $regex_branch ]]; then
+        local major="${BASH_REMATCH[1]}"
+        local feature="${BASH_REMATCH[2]}"
+        local minor="${BASH_REMATCH[3]}"
+        local future_tag="${major}.${feature}.${minor}"
+        echo "Future tag: ${future_tag}"
+        git checkout "$prod_branch"
+        git fetch "$j2s_remote"
+        git reset --hard "$j2s_remote/$prod_branch"
+        echo "Merging release ${branch} in $prod_branch branch..."
+        git merge --no-ff "${branch}" -m "Merge release branch : ${branch}"
+        echo "Create new tag ${future_tag}"
+        git tag "${future_tag}"
+        git push "$j2s_remote" "$prod_branch"
+        echo "Delete local branch ${branch}"
+        git branch -D "${branch}"
+        echo "Delete remote branch ${branch}"
+        git push -d "$j2s_remote" "${branch}"
+        git push "$j2s_remote" tag "${future_tag}"
+        gh release create "${future_tag}" --generate-notes
+    else
+        echo "Release branch seems to have a wrong format..."
+        exit_safe 1
+    fi
 }


### PR DESCRIPTION
Refonte complète des méthode d'appel pour gagner en cohérence
Ajout de la gestion de branche démo (équivalent de preprod)

Nouveau fonctionnement
## Usage
jgit se pilote directement depuis le dossier de votre projet :

```
cd /chemin/vers/mon-projet
jgit <scope> <action> [<target>] [options…]
```

### Scopes disponibles

- `feature` / `hotfix`
- `release`
- `demo`
- `util`

### Options communes

- `--based-on <branch>` : branche de référence lors d'un `start` ou d'un `rebase`.
- `--from <branch>` : source d'un merge (option répétable).
- `--into <branch>` : destination explicite du merge (sinon la branche courante est utilisée quand pertinent).
- `--yes` : valide automatiquement toutes les confirmations.
- `--no-open` : n'ouvre pas automatiquement la PR lors d'un `feature/hotfix start` ou `restart`.
- `jgit help` ou `jgit -h` : affiche l'aide détaillée.

### Feature & Hotfix

- `jgit feature start <ticket> [--based-on <branch>] [--no-open]` — crée ou reprend `feature/<ticket>` ainsi que la branche PR `__PR__feature/<ticket>`. Une PR GitHub est ouverte sauf si `--no-open` est présent. Le comportement est identique avec `hotfix`.
- `jgit feature restart <ticket> [--no-open]` — recrée `feature/<ticket>` depuis la branche PR après vérification du code. Supprime et repousse la branche de travail avant de rouvrir la PR (optionnellement sans l'ouvrir grâce à `--no-open`).
- `jgit feature rebase <ticket> [--based-on <branch>]` — gère le rebase complet : vérifications, cherry-pick sur des branches temporaires `jgit_rebase_*`, renommage et force-push final. Disponible également pour `hotfix`.

### Release

- `jgit release start [<x.y.z>]` — sans cible, calcule le prochain numéro de version (`x.y.z`) à partir du dernier tag, crée ou reprend la branche `release/x.y.z` et pousse le commit d'initialisation. Avec une cible explicite, la branche `release/<x.y.z>` correspondante est préparée.
- `jgit release merge [<x.y.z>] --from <branch> [--into <branch>]` — garantit que la branche de release est prête (création ou simple checkout) puis fusionne chaque branche listée avec `--from` dans la release. Les noms avec ou sans préfixe `__PR__` sont acceptés.
- `jgit release finish [--into <release/x.y.z>]` — vérifie la cohérence de la release courante (ou de celle indiquée), fusionne dans `branch_prod`, crée le tag, supprime la branche de release localement/distante et génère la release GitHub.

### Demo

- `jgit demo start [<demo_name>] [--based-on <branch>]` — prépare une branche `demo_<nom>` existante (checkout + fast-forward) ou en crée une nouvelle basée sur la branche fournie, après confirmation.
- `jgit demo merge [--into <demo_branch>] --from feature/<ticket> [--from hotfix/<ticket>]…` — merge en série chaque branche fournie dans la démo cible (branche courante par défaut). La branche est tenue linéaire via rebase et `--force-with-lease`.
- `jgit demo list` — liste les marqueurs `[jgit] DEMO …` depuis le commit d'initialisation, affiche les branches fusionnées et suggère les commandes `jgit release merge --from …` correspondantes.
- `jgit demo remove [--yes]` — après confirmation, supprime la branche de démo sur le remote puis en local et vous replace sur la branche de référence.

### Utility

- `jgit util clean` — supprime les branches locales temporaires utilisées par jgit (`jgit_rebase_*`, `__PR__*`).
